### PR TITLE
Don't use inspect.stack()

### DIFF
--- a/tests/test_varname.py
+++ b/tests/test_varname.py
@@ -10,19 +10,6 @@ from varname import (varname,
                      _get_node,
                      nameof)
 
-@pytest.fixture
-def monkey_patch():
-    """Monkey-patch inspect.stack to get only one frame,
-    which happens in R package reticulate."""
-    from varname import inspect
-
-    orig_stack = inspect.stack
-    inspect.stack = lambda *args, **kwargs: orig_stack(*args, **kwargs)[:1]
-
-    yield
-
-    inspect.stack = orig_stack
-
 def test_function():
 
     def function():
@@ -321,6 +308,11 @@ def test_will():
     func = i_will().abc
     assert func.will == 'abc'
 
+    with pytest.raises(ValueError):
+        func = i_will().abc
+        assert func.will == 'abc'
+        raise ValueError
+
 def test_will_deep():
 
     def get_will():
@@ -363,43 +355,23 @@ def test_will_fail():
     with pytest.raises(VarnameRetrievingError):
         get_will()['a']
 
-def test_frame_fail(monkey_patch):
-    """Test when failed to retrieve the frame"""
-    # Let's monkey-patch inspect.stack to do this
-    assert _get_node(1) is None
 
-def test_frame_fail_varname(monkey_patch):
+def test_frame_fail_varname():
+    def func():
+        return varname()
 
-    def func(raise_exc):
-        return varname(raise_exc=raise_exc)
+    with pytest.raises(ValueError):
+        a = func()
+        assert a == 'a'
+        raise ValueError
 
-    with pytest.raises(VarnameRetrievingError):
-        a = func(True)
 
-    with pytest.warns(VarnameRetrievingWarning):
-        b = func(False)
-    assert b.startswith('var_')
-
-def test_frame_fail_nameof(monkey_patch):
-
+def test_frame_fail_nameof():
     a = 1
-    with pytest.raises(VarnameRetrievingError):
-        nameof(a)
+    with pytest.raises(ValueError):
+        assert nameof(a) == 'a'
+        raise ValueError
 
-def test_frame_fail_will(monkey_patch):
-
-    def func(raise_exc):
-        wil = will(raise_exc=raise_exc)
-        ret = lambda: None
-        ret.a = 1
-        ret.will = wil
-        return ret
-
-    with pytest.raises(VarnameRetrievingError):
-        func(True).a
-
-    assert func(False).a == 1
-    assert func(False).will is None
 
 def test_namedtuple():
     Name = namedtuple(['first', 'last'])

--- a/varname.py
+++ b/varname.py
@@ -27,12 +27,10 @@ def _get_node(caller):
 
     When the node can not be retrieved, try to return the first statement.
     """
-    try:
-        frame = inspect.stack()[caller+2].frame
-    except IndexError:
-        return None
-    else:
-        exet = executing.Source.executing(frame)
+    frame = inspect.currentframe().f_back.f_back
+    for _ in range(caller):
+        frame = frame.f_back
+    exet = executing.Source.executing(frame)
 
     if exet.node:
         return exet.node


### PR DESCRIPTION
inspect.stack() is a really inefficient way to get just one frame. It adds all sorts of stuff you don't need. That was my initial motivation for this.

I see now that it was causing you several other problems and that's the real reason #7 fixed some stuff. So now the package is more robust and works inside `with pytest.raises`.