### PR TITLE
Support attributes in varname and nameof

### DIFF
--- a/tests/test_varname.py
+++ b/tests/test_varname.py
@@ -322,10 +322,7 @@ def test_nameof_expr():
 
     lam = lambda: 0
     lam.a = 1
-    with pytest.raises(VarnameRetrievingError) as vrerr:
-        varname_module.nameof(test, lam.a)
-    assert str(vrerr.value) == ("Only variables should "
-                                "be passed to nameof.")
+    assert varname_module.nameof(test, lam.a) == ("test", "a")
 
 def test_class_property():
     class C:

--- a/tests/test_varname.py
+++ b/tests/test_varname.py
@@ -327,10 +327,19 @@ class TestNameof(unittest.TestCase):
 
         lam = lambda: 0
         lam.a = 1
+        lam.lam = lam
+        lams = [lam]
         self.assertEqual(
             varname_module.nameof(test, lam.a),
             ("test", "a"),
         )
+
+        self.assertEqual(nameof(lam.a), "a")
+        self.assertEqual(nameof(lam.lam.lam.lam.a), "a")
+        self.assertEqual(nameof(lam.lam.lam.lam), "lam")
+        self.assertEqual(nameof(lams[0].lam), "lam")
+        self.assertEqual(nameof(lams[0].lam.a), "a")
+        self.assertEqual(nameof((lam() or lams[0]).lam.a), "a")
 
 
 def test_nameof_pytest_fail():

--- a/varname.py
+++ b/varname.py
@@ -160,14 +160,20 @@ def varname(caller=1, raise_exc=False):
                       "on the very left will be used.",
                       MultipleTargetAssignmentWarning)
     target = node.targets[0]
+    return _node_name(target)
 
-    # must be a variable
-    if isinstance(target, ast.Name):
-        return target.id
 
-    raise VarnameRetrievingError(
-        f"Invaid variable assigned: {ast.dump(target)!r}"
-    )
+def _node_name(node):
+    if isinstance(node, ast.Name):
+        return node.id
+    elif isinstance(node, ast.Attribute):
+        return node.attr
+    else:
+        raise VarnameRetrievingError(
+            f"Can only get name of a variable or attribute, "
+            f"not {ast.dump(node)}"
+        )
+
 
 def will(caller=1, raise_exc=False):
     """Detect the attribute name right immediately after a function call.
@@ -263,10 +269,7 @@ def nameof(*args, caller=1):
 
     ret = []
     for arg in node.args:
-        if not isinstance(arg, ast.Name):
-            raise VarnameRetrievingError("Only variables should "
-                                         "be passed to nameof.")
-        ret.append(arg.id)
+        ret.append(_node_name(arg))
 
     if not ret:
         raise VarnameRetrievingError("At least one variable should be "

--- a/varname.py
+++ b/varname.py
@@ -166,13 +166,13 @@ def varname(caller=1, raise_exc=False):
 def _node_name(node):
     if isinstance(node, ast.Name):
         return node.id
-    elif isinstance(node, ast.Attribute):
+    if isinstance(node, ast.Attribute):
         return node.attr
-    else:
-        raise VarnameRetrievingError(
-            f"Can only get name of a variable or attribute, "
-            f"not {ast.dump(node)}"
-        )
+
+    raise VarnameRetrievingError(
+        f"Can only get name of a variable or attribute, "
+        f"not {ast.dump(node)}"
+    )
 
 
 def will(caller=1, raise_exc=False):


### PR DESCRIPTION
For example `nameof(self.x) == 'x'`. I think this is a pretty intuitive enhancement. The bytecode version already does this.