### PR TITLE
Allow using will() outside properties/methods

### DIFF
--- a/tests/test_varname.py
+++ b/tests/test_varname.py
@@ -421,7 +421,7 @@ def test_will_method():
         def __init__(self):
             self.will = None
 
-        def permit(self):
+        def permit(self, *_):
             self.will = will()
             if self.will == 'do':
                 # let self handle do
@@ -432,6 +432,8 @@ def test_will_method():
             if self.will != 'do':
                 raise AttributeError("You don't have permission to do")
             return 'I am doing!'
+
+        __getitem__ = permit
 
     awesome = AwesomeClass()
     with pytest.raises(AttributeError) as exc:
@@ -445,23 +447,12 @@ def test_will_method():
     ret = awesome.permit().do()
     assert ret == 'I am doing!'
 
-def test_will_malformat():
-    """Function will has to be used in the format of `inst.attr` or
-    `inst.attr()`"""
-    class C1:
-        def __getitem__(self, name):
-            return will(raise_exc=True)
+    with pytest.raises(AttributeError) as exc:
+        print(awesome[2])
+    assert str(exc.value) == 'Should do something with AwesomeClass object'
 
-    class C2:
-        def __getitem__(self, name):
-            return will(raise_exc=False)
-
-    c1 = C1()
-    with pytest.raises(VarnameRetrievingError):
-        c1[1]
-
-    c2_will = C2()[1]
-    assert c2_will is None
+    ret = awesome[2].do()
+    assert ret == 'I am doing!'
 
 
 def test_will_fail():

--- a/varname.py
+++ b/varname.py
@@ -174,13 +174,6 @@ def will(caller=1, raise_exc=False):
             raise VarnameRetrievingError("Unable to retrieve the frame.")
         return None
 
-    # have to be called like: inst.attr or inst.attr()
-    # see test_will_malformat
-    if not isinstance(node, (ast.Attribute, ast.Call)):
-        if raise_exc:
-            raise VarnameRetrievingError("Invalid use of function `will`")
-        return None
-
     # try to get not inst.attr from inst.attr()
     # ast.Call/Attribute always has parent
     # see: https://docs.python.org/3/library/ast.html#abstract-grammar


### PR DESCRIPTION
Followup from https://github.com/pwwang/python-varname/pull/15#issuecomment-671517285. Basically I see no reason for the previous restrictions.