### PR TITLE
Deprecate inject and introduce register to register classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ pip install varname
 - Fetching variable names directly using `nameof`
 - A value wrapper to store the variable name that a value is assigned to using `Wrapper`
 - Detecting next immediate attribute name using `will`
-- Injecting `__varname__` to objects
+- Injecting `__varname__` to classes
 - A `debug` function to print variables with their names and values.
 
 ## Credits
@@ -213,26 +213,21 @@ awesome.permit() # AttributeError: Should do something with AwesomeClass object
 awesome.permit().do() == 'I am doing!'
 ```
 
-### Injecting `__varname__`
+### Injecting `__varname__` to classes
 
 ```python
-from varname import inject
+from varname import inject_varname
 
-class MyList(list):
+@inject_varname
+class Dict(dict):
     pass
 
-a = inject(MyList())
-b = inject(MyList())
-
+a = Dict(a=1)
+b = Dict(b=2)
 a.__varname__ == 'a'
 b.__varname__ == 'b'
-
-a == b
-
-# other methods not affected
-a.append(1)
-b.append(1)
-a == b
+a.update(b)
+a == {'a':1, 'b':2}
 ```
 
 ### Debugging with `debug`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v0.5.5
+- Deprecate inject and use inject_varname decorator instead
+
 ## v0.5.4
 - Allow `varname.varname` to receive multiple variables on the left-hand side
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "varname"
-version = "0.5.4"
+version = "0.5.5"
 description = "Dark magics about variable names in python."
 authors = [ "pwwang <pwwang@pwwang.com>",]
 license = "MIT"

--- a/tests/test_varname.py
+++ b/tests/test_varname.py
@@ -572,3 +572,18 @@ def test_debug(capsys):
     assert 'DEBUG: a=1\n' == capsys.readouterr().out
     debug(a, b, merge=True)
     assert 'DEBUG: a=1, b=<object' in capsys.readouterr().out
+
+def test_inject_varname():
+
+    @inject_varname
+    class Foo:
+        def __init__(self, a=1):
+            self.a = a
+
+    f = Foo()
+    assert f.__varname__ == 'f'
+    assert f.a == 1
+
+    f2 = Foo(2)
+    assert f2.__varname__ == 'f2'
+    assert f2.a == 2

--- a/varname.py
+++ b/varname.py
@@ -181,6 +181,9 @@ def inject(obj: object) -> object:
     Returns:
         The object with __varname__ injected
     """
+    warnings.warn("Function inject will be removed in 0.6.0. Use "
+                  "varname.register to register your class.",
+                  DeprecationWarning)
     vname = varname()
     try:
         setattr(obj, '__varname__', vname)

--- a/varname.py
+++ b/varname.py
@@ -11,7 +11,7 @@ from functools import lru_cache
 
 import executing
 
-__version__ = "0.5.4"
+__version__ = "0.5.5"
 __all__ = [
     "VarnameRetrievingError", "varname", "will", "inject_varname",
     "inject", "nameof", "namedtuple", "Wrapper", "debug"


### PR DESCRIPTION
Instead of:
```python
class Foo:
  ...

foo = varname.inject(Foo())
# foo.__varname__ == 'foo'
```
do:
```python
@varname.inject_varname
class Foo:
  ...

foo = Foo()
# foo.__varname__ == 'foo'
```