### PR TITLE
Using argname to reimplement nameof

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,8 @@ debug(a, b)
 debug(a, b, merge=True)
 # DEBUG: a='value', b=<object object at 0x2b70580e5f20>
 debug(a, repr=False, prefix='') # a=value
+# also debug an expression
+debug(a+a, vars_only=False) # DEBUG: a+a='valuevalue'
 ```
 
 ## Reliability and limitations

--- a/README.md
+++ b/README.md
@@ -316,7 +316,9 @@ debug(a, b, merge=True)
 # DEBUG: a='value', b=<object object at 0x2b70580e5f20>
 debug(a, repr=False, prefix='') # a=value
 # also debug an expression
-debug(a+a, vars_only=False) # DEBUG: a+a='valuevalue'
+debug(a+a) # DEBUG: a+a='valuevalue'
+# If you want to disable it:
+debug(a+a, vars_only=True) # error
 ```
 
 ## Reliability and limitations
@@ -333,14 +335,12 @@ For example:
 - This will not work with `pytest`:
   ```python
   a = 1
-  assert nameof(a) == 'a'
+  assert nameof(a) == 'a' # pytest manipulated the ast here
 
   # do this instead
   name_a = nameof(a)
   assert name_a == 'a'
   ```
-
-- `R` with `reticulate`.
 
 [1]: https://github.com/pwwang/python-varname
 [2]: https://github.com/HanyuuLu

--- a/README.rst
+++ b/README.rst
@@ -388,6 +388,8 @@ Debugging with ``debug``
    debug(a, b, merge=True)
    # DEBUG: a='value', b=<object object at 0x2b70580e5f20>
    debug(a, repr=False, prefix='') # a=value
+   # also debug an expression
+   debug(a+a, vars_only=False) # DEBUG: a+a='valuevalue'
 
 Reliability and limitations
 ---------------------------

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v0.6.2
+- Remove argument `full` for `nameof`, use `vars_only` instead. When `vars_only=False`, source of the argument returned.
+- Add argument `frame` to `argname`, so that it can be wrapped.
+- Allow `argname` to fetch the source of variable keyword arguments (`**kwargs`), which will be an empty dict (`{}`) when no keyword arguments passed.
+- Add argument `pos_only` to `argname` to only match the positional arguments
+- Allow variable positional arguments for `argname` so that `argname(*args)` is allowed
+- Add `vars_only` argument to `helpers.debug` so source of expression becomes available
+
 ## v0.6.1
 - Add `argname` to retrieve argument names/sources passed to a function
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,10 +1,70 @@
 ## v0.6.2
 - Remove argument `full` for `nameof`, use `vars_only` instead. When `vars_only=False`, source of the argument returned.
+  ```python
+  # before:
+  nameof(a.b, full=True) # 'a.b'
+  nameof(x[0], full=True) # unable to fetch
+  # after (requires asttoken):
+  nameof(a.b, vars_only=False) # 'a.b'
+  nameof(x[0], vars_only=False) # 'x[0]'
+  ```
 - Add argument `frame` to `argname`, so that it can be wrapped.
+  ```python
+  def argname2(arg, *more_args):
+      return argname(arg, *more_args, frame=2)
+  ```
 - Allow `argname` to fetch the source of variable keyword arguments (`**kwargs`), which will be an empty dict (`{}`) when no keyword arguments passed.
+  ```python
+  def func(a, **kwargs):
+      return argname(a, kwargs)
+  # before:
+  func(x) # raises error
+  # after:
+  func(x) # returns ('x', {})
+  ```
 - Add argument `pos_only` to `argname` to only match the positional arguments
+  ```python
+  # before
+  def func(a, b=1):
+    return argname(a)
+  func(x) # 'x'
+  func(x, b=2) # error since 2 is not ast.Name
+
+  # after
+  def func(a, b=1):
+    return argname(a, pos_only=True)
+  func(x) # 'x'
+  func(x, b=2) # 'x'
+  ```
+- Parse the arguments only if needed
+  ```python
+  # before
+  def func(a, b):
+    return argname(a)
+  func(x, 1) # NonVariableArgumentError
+
+  # after
+  func(x, 1) # 'x'
+  ```
 - Allow variable positional arguments for `argname` so that `argname(*args)` is allowed
-- Add `vars_only` argument to `helpers.debug` so source of expression becomes available
+  ```python
+  # before
+  def func(arg, *args):
+    return argname(arg, args) # *args not allowed
+  x = y = 1
+  func(x, y) # ('x', ('y', 1))
+
+  # after
+  def func(arg, *args):
+    return argname(arg, *args)
+  x = y = 1
+  func(x, y) # ('x', 'y')
+  ```
+- Add `vars_only` (defaults to `False`) argument to `helpers.debug` so source of expression becomes available
+  ```python
+  a=1
+  debug(a+a) # DEBUG: a+a=2
+  ```
 
 ## v0.6.1
 - Add `argname` to retrieve argument names/sources passed to a function

--- a/playground/playground.ipynb
+++ b/playground/playground.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -57,14 +57,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": "'f'"
      },
-     "execution_count": 32,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -79,14 +79,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": "'foo'"
      },
-     "execution_count": 33,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -109,7 +109,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -162,14 +162,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": "'f'"
      },
-     "execution_count": 35,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -187,14 +187,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": "'foo'"
      },
-     "execution_count": 36,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -220,14 +220,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": "'f'"
      },
-     "execution_count": 37,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -252,14 +252,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": "'f'"
      },
-     "execution_count": 38,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -286,7 +286,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -317,14 +317,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": "'f'"
      },
-     "execution_count": 40,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -356,26 +356,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[varname.utils] DEBUG: Ignored by IgnoreModule('varname') [In 'varname' at /home/pwwang/github/python-varname/varname/core.py:82]\n",
-      "[varname.utils] DEBUG: Ignored by IgnoreModule('module_all_calls') [In 'func' at /home/pwwang/github/python-varname/playground/module_all_calls.py:6]\n",
-      "[varname.utils] DEBUG: Ignored by IgnoreModule('module_all_calls') [In 'func2' at /home/pwwang/github/python-varname/playground/module_all_calls.py:9]\n",
-      "[varname.utils] DEBUG: Ignored by IgnoreModule('module_all_calls') [In 'func3' at /home/pwwang/github/python-varname/playground/module_all_calls.py:12]\n",
-      "[varname.utils] DEBUG: Skipping (0 more to skip) [In 'func' at <ipython-input-41-8d0a7ff1a188>:4]\n",
-      "[varname.utils] DEBUG: Gotcha! [In '<module>' at <ipython-input-41-8d0a7ff1a188>:7]\n"
+      "[varname] DEBUG: Ignored by IgnoreModule('varname') [In 'varname' at /home/pwwang/github/python-varname/varname/core.py:84]\n",
+      "[varname] DEBUG: Ignored by IgnoreModule('module_all_calls') [In 'func' at /home/pwwang/github/python-varname/playground/module_all_calls.py:6]\n",
+      "[varname] DEBUG: Ignored by IgnoreModule('module_all_calls') [In 'func2' at /home/pwwang/github/python-varname/playground/module_all_calls.py:9]\n",
+      "[varname] DEBUG: Ignored by IgnoreModule('module_all_calls') [In 'func3' at /home/pwwang/github/python-varname/playground/module_all_calls.py:12]\n",
+      "[varname] DEBUG: Skipping (0 more to skip) [In 'func' at <ipython-input-11-8d0a7ff1a188>:4]\n",
+      "[varname] DEBUG: Gotcha! [In '<module>' at <ipython-input-11-8d0a7ff1a188>:7]\n"
      ]
     },
     {
      "data": {
       "text/plain": "'f'"
      },
-     "execution_count": 41,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -401,25 +401,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[varname.utils] DEBUG: Ignored by IgnoreModule('varname') [In 'varname' at /home/pwwang/github/python-varname/varname/core.py:82]\n",
-      "[varname.utils] DEBUG: Ignored by IgnoreModuleQualname('module_glob_qualname', '_func*') [In '_func' at /home/pwwang/github/python-varname/playground/module_glob_qualname.py:6]\n",
-      "[varname.utils] DEBUG: Ignored by IgnoreModuleQualname('module_glob_qualname', '_func*') [In '_func2' at /home/pwwang/github/python-varname/playground/module_glob_qualname.py:9]\n",
-      "[varname.utils] DEBUG: Skipping (0 more to skip) [In 'func3' at /home/pwwang/github/python-varname/playground/module_glob_qualname.py:12]\n",
-      "[varname.utils] DEBUG: Gotcha! [In '<module>' at <ipython-input-42-07ea87f561cc>:4]\n"
+      "[varname] DEBUG: Ignored by IgnoreModule('varname') [In 'varname' at /home/pwwang/github/python-varname/varname/core.py:84]\n",
+      "[varname] DEBUG: Ignored by IgnoreModuleQualname('module_glob_qualname', '_func*') [In '_func' at /home/pwwang/github/python-varname/playground/module_glob_qualname.py:6]\n",
+      "[varname] DEBUG: Ignored by IgnoreModuleQualname('module_glob_qualname', '_func*') [In '_func2' at /home/pwwang/github/python-varname/playground/module_glob_qualname.py:9]\n",
+      "[varname] DEBUG: Skipping (0 more to skip) [In 'func3' at /home/pwwang/github/python-varname/playground/module_glob_qualname.py:12]\n",
+      "[varname] DEBUG: Gotcha! [In '<module>' at <ipython-input-12-07ea87f561cc>:4]\n"
      ]
     },
     {
      "data": {
       "text/plain": "'f'"
      },
-     "execution_count": 42,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -442,7 +442,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -469,24 +469,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[varname.utils] DEBUG: Ignored by IgnoreModule('varname') [In 'varname' at /home/pwwang/github/python-varname/varname/core.py:82]\n",
-      "[varname.utils] DEBUG: Skipping (0 more to skip) [In 'func' at <ipython-input-44-d27bbc23b8df>:2]\n",
-      "[varname.utils] DEBUG: Ignored by IgnoreOnlyQualname(None, '*<lambda>') [In '<lambda>' at <ipython-input-44-d27bbc23b8df>:4]\n",
-      "[varname.utils] DEBUG: Gotcha! [In '<module>' at <ipython-input-44-d27bbc23b8df>:7]\n"
+      "[varname] DEBUG: Ignored by IgnoreModule('varname') [In 'varname' at /home/pwwang/github/python-varname/varname/core.py:84]\n",
+      "[varname] DEBUG: Skipping (0 more to skip) [In 'func' at <ipython-input-14-d27bbc23b8df>:2]\n",
+      "[varname] DEBUG: Ignored by IgnoreOnlyQualname(None, '*<lambda>') [In '<lambda>' at <ipython-input-14-d27bbc23b8df>:4]\n",
+      "[varname] DEBUG: Gotcha! [In '<module>' at <ipython-input-14-d27bbc23b8df>:7]\n"
      ]
     },
     {
      "data": {
       "text/plain": "'f'"
      },
-     "execution_count": 44,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -511,24 +511,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[varname.utils] DEBUG: Ignored by IgnoreModule('varname') [In 'varname' at /home/pwwang/github/python-varname/varname/core.py:82]\n",
-      "[varname.utils] DEBUG: Skipping (0 more to skip) [In '__init__' at <ipython-input-45-833ae7542d7b>:9]\n",
-      "[varname.utils] DEBUG: Ignored by IgnoreDirname('/home/pwwang/miniconda3/lib/python3.7/') [In '__call__' at /home/pwwang/miniconda3/lib/python3.7/typing.py:678]\n",
-      "[varname.utils] DEBUG: Gotcha! [In '<module>' at <ipython-input-45-833ae7542d7b>:12]\n"
+      "[varname] DEBUG: Ignored by IgnoreModule('varname') [In 'varname' at /home/pwwang/github/python-varname/varname/core.py:84]\n",
+      "[varname] DEBUG: Skipping (0 more to skip) [In '__init__' at <ipython-input-15-833ae7542d7b>:9]\n",
+      "[varname] DEBUG: Ignored by IgnoreDirname('/home/pwwang/miniconda3/lib/python3.7/') [In '__call__' at /home/pwwang/miniconda3/lib/python3.7/typing.py:678]\n",
+      "[varname] DEBUG: Gotcha! [In '<module>' at <ipython-input-15-833ae7542d7b>:12]\n"
      ]
     },
     {
      "data": {
       "text/plain": "'foo'"
      },
-     "execution_count": 45,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -559,14 +559,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": "'f'"
      },
-     "execution_count": 46,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -602,25 +602,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[varname.utils] DEBUG: Ignored by IgnoreModule('varname') [In 'varname' at /home/pwwang/github/python-varname/varname/core.py:82]\n",
-      "[varname.utils] DEBUG: Ignored by IgnoreDecorated('wrapper', 2) [In 'func' at <ipython-input-47-e7a4675a5e8e>:4]\n",
-      "[varname.utils] DEBUG: Skipping (1 more to skip) [In 'wrapper' at <ipython-input-47-e7a4675a5e8e>:9]\n",
-      "[varname.utils] DEBUG: Skipping (0 more to skip) [In 'func3' at <ipython-input-47-e7a4675a5e8e>:18]\n",
-      "[varname.utils] DEBUG: Gotcha! [In '<module>' at <ipython-input-47-e7a4675a5e8e>:21]\n"
+      "[varname] DEBUG: Ignored by IgnoreModule('varname') [In 'varname' at /home/pwwang/github/python-varname/varname/core.py:84]\n",
+      "[varname] DEBUG: Ignored by IgnoreDecorated('wrapper', 2) [In 'func' at <ipython-input-17-e7a4675a5e8e>:4]\n",
+      "[varname] DEBUG: Skipping (1 more to skip) [In 'wrapper' at <ipython-input-17-e7a4675a5e8e>:9]\n",
+      "[varname] DEBUG: Skipping (0 more to skip) [In 'func3' at <ipython-input-17-e7a4675a5e8e>:18]\n",
+      "[varname] DEBUG: Gotcha! [In '<module>' at <ipython-input-17-e7a4675a5e8e>:21]\n"
      ]
     },
     {
      "data": {
       "text/plain": "'f'"
      },
-     "execution_count": 47,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -659,7 +659,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -710,7 +710,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -724,7 +724,7 @@
      "data": {
       "text/plain": "'None'"
      },
-     "execution_count": 49,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -753,7 +753,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -781,14 +781,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": "'x'"
      },
-     "execution_count": 51,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -807,7 +807,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -816,7 +816,8 @@
      "text": [
       "x.a\n",
       "x.a.b\n",
-      "('x.a', 'x.a.b')\n"
+      "('x.a', 'x.a.b')\n",
+      "x.a()\n"
      ]
     }
    ],
@@ -824,9 +825,10 @@
     "x.a = x\n",
     "x.a.b = x\n",
     "\n",
-    "print(nameof(x.a, full=True))\n",
-    "print(nameof(x.a.b, full=True))\n",
-    "print(nameof(x.a, x.a.b, full=True))"
+    "print(nameof(x.a, vars_only=False))\n",
+    "print(nameof(x.a.b, vars_only=False))\n",
+    "print(nameof(x.a, x.a.b, vars_only=False))\n",
+    "print(nameof(x.a(), vars_only=False))"
    ]
   },
   {
@@ -838,23 +840,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": "'x'"
      },
-     "execution_count": 53,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "def nameof2(*args, **kwargs):\n",
-    "    return nameof(*args, **kwargs)\n",
+    "def nameof2(var, *more_vars):\n",
+    "    return nameof(var, *more_vars, frame=2)\n",
     "\n",
-    "nameof2(x, frame=2)"
+    "nameof2(x)"
    ]
   },
   {
@@ -866,7 +868,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
@@ -904,7 +906,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
@@ -942,6 +944,32 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "x\n",
+      "('x', 'y', 'x')\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Wrap argname\n",
+    "def argname2(arg, *more_args):\n",
+    "    return argname(arg, *more_args, frame=2)\n",
+    "\n",
+    "def func(*args):\n",
+    "    return argname2(*args)\n",
+    "\n",
+    "print(func(x))\n",
+    "print(func(x, y, x))"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -957,7 +985,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
@@ -994,7 +1022,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [
     {
@@ -1038,14 +1066,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": "'f'"
      },
-     "execution_count": 58,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1068,14 +1096,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": "'foo'"
      },
-     "execution_count": 59,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1098,7 +1126,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [
     {
@@ -1111,7 +1139,8 @@
       "DEBUG: b='2'\n",
       "DEBUG: a='1', b='2'\n",
       "DEBUG: a=1, b=2\n",
-      "DEBUG VARS: a='1', b='2'\n"
+      "DEBUG VARS: a='1', b='2'\n",
+      "DEBUG: a+b='12'\n"
      ]
     }
    ],
@@ -1123,7 +1152,8 @@
     "debug(a, b)\n",
     "debug(a, b, merge=True)\n",
     "debug(a, b, merge=True, repr=False)\n",
-    "debug(a, b, merge=True, prefix='DEBUG VARS: ')\n"
+    "debug(a, b, merge=True, prefix='DEBUG VARS: ')\n",
+    "debug(a+b, vars_only=False)\n"
    ]
   }
  ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "varname"
-version = "0.6.1"
+version = "0.6.2"
 description = "Dark magics about variable names in python."
 authors = [ "pwwang <pwwang@pwwang.com>",]
 license = "MIT"
@@ -15,6 +15,8 @@ repository = "https://github.com/pwwang/python-varname"
 [tool.poetry.dependencies]
 python = "^3.6"
 executing = "*"
+asttokens = { version = "2.*", optional = true }
+pure_eval = { version = "0.*", optional = true }
 
 [tool.poetry.dev-dependencies]
 pytest = "*"

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ if os.path.exists(readme_path):
 setup(
     long_description=readme,
     name='varname',
-    version='0.6.1',
+    version='0.6.2',
     description='Dark magics about variable names in python.',
     python_requires='==3.*,>=3.6.0',
     project_urls={"homepage": "https://github.com/pwwang/python-varname", "repository": "https://github.com/pwwang/python-varname"},
@@ -34,6 +34,6 @@ setup(
     packages=['varname'],
     package_dir={"": "."},
     package_data={},
-    install_requires=['executing'],
-    extras_require={"dev": ["asttokens==2.*", "pure-eval==0.*", "pytest", "pytest-cov"]},
+    install_requires=['asttokens==2.*', 'executing', 'pure-eval==0.*'],
+    extras_require={"dev": ["pytest", "pytest-cov"]},
 )

--- a/tests/test_argname.py
+++ b/tests/test_argname.py
@@ -237,3 +237,10 @@ def test_argname_nosuch_varpos_arg():
     ):
         func(x, y)
 
+def test_argname_target_arg():
+    def func(a, b):
+        return argname(a)
+
+    x = 1
+    names = func(x, 1)
+    assert names == 'x'

--- a/tests/test_argname.py
+++ b/tests/test_argname.py
@@ -1,3 +1,5 @@
+import textwrap
+
 import pytest
 from varname import *
 
@@ -158,3 +160,57 @@ def test_argname_star_args_individual():
         return argname(args[x])
     with pytest.raises(ValueError, match="to be a constant"):
         func(x, y, z)
+
+def test_argname_argname_node_na():
+    source = textwrap.dedent(f"""\
+        from varname import argname
+        def func(a):
+            return argname(a)
+
+        x = 1
+        print(func(x))
+    """)
+    code = compile(source, '<string343>', 'exec')
+    with pytest.raises(
+            VarnameRetrievingError,
+            match="The source code of 'argname' calling is not available"
+    ):
+        exec(code)
+
+def test_argname_func_node_na():
+    def func(a):
+        return argname(a)
+
+    with pytest.raises(
+            VarnameRetrievingError,
+            match="The source code of 'argname' calling is not available"
+    ):
+        exec('x=1; func(x)')
+
+def test_argname_func_na():
+    def func(a):
+        return argname(a)
+
+    with pytest.raises(
+            VarnameRetrievingError,
+            match="The source code of 'argname' calling is not available"
+    ):
+        exec('x=1; func(x)')
+
+def test_argname_wrapper():
+
+    def decorator(f):
+        def wrapper(arg, *more_args):
+            name, more = f(arg, more_args, frame=2)
+            return (name, *more)
+
+        return wrapper
+
+    argname2 = decorator(argname)
+
+    def func(a, b):
+        return argname2(a, b)
+
+    x = y = 1
+    names = func(x, y)
+    assert names == ('x', 'y')

--- a/tests/test_argname.py
+++ b/tests/test_argname.py
@@ -201,8 +201,7 @@ def test_argname_wrapper():
 
     def decorator(f):
         def wrapper(arg, *more_args):
-            name, more = f(arg, more_args, frame=2)
-            return (name, *more)
+            return f(arg, *more_args, frame=2)
 
         return wrapper
 
@@ -214,3 +213,27 @@ def test_argname_wrapper():
     x = y = 1
     names = func(x, y)
     assert names == ('x', 'y')
+
+def test_argname_varpos_arg():
+    def func(a, *args, **kwargs):
+        return argname(kwargs, a, *args)
+
+    x = y = z = 1
+    names = func(x, y, kw=z)
+    assert names == ({'kw': 'z'}, 'x', 'y')
+
+    names = func(x)
+    assert names == ({}, 'x')
+
+def test_argname_nosuch_varpos_arg():
+    def func(a, *args):
+        another = []
+        return argname(a, *another)
+
+    x = y = 1
+    with pytest.raises(
+            ValueError,
+            match="No such variable positional argument"
+    ):
+        func(x, y)
+

--- a/tests/test_bytecode_nameof.py
+++ b/tests/test_bytecode_nameof.py
@@ -12,11 +12,9 @@ def bytecode_nameof(frame):
 
 def nameof_both(var, *more_vars):
     """Test both implementations at the same time"""
-    if more_vars:
-        res, more = nameof(var, more_vars, frame=2)
-        result = (res, *more)
-    else:
-        result = nameof(var, frame=2)
+    result = nameof(var, *more_vars, frame=2)
+
+    if not more_vars:
         assert result == bytecode_nameof(frame=2)
     return result
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -36,6 +36,9 @@ def test_debug(capsys):
     assert 'DEBUG: a=1\n' == capsys.readouterr().out
     debug(a, b, merge=True)
     assert 'DEBUG: a=1, b=<object' in capsys.readouterr().out
+    debug(a+a, vars_only=False)
+    assert 'DEBUG: a+a=2' in capsys.readouterr().out
+
 
 def test_register_to_class():
 

--- a/tests/test_nameof.py
+++ b/tests/test_nameof.py
@@ -88,8 +88,7 @@ def test_nameof_wrapper():
 
     def decorator(f):
         def wrapper(var, *more_vars):
-            name, more = f(var, more_vars, frame=2)
-            return (name, *more)
+            return f(var, *more_vars, frame=2)
 
         return wrapper
 

--- a/tests/test_nameof.py
+++ b/tests/test_nameof.py
@@ -28,33 +28,33 @@ def test_nameof_full():
     assert name == 'a'
     name = nameof(a.b)
     assert name == 'b'
-    name = nameof(a.b, full=True)
+    name = nameof(a.b, vars_only=False)
     assert name == 'a.b'
     name = nameof(a.b.c)
     assert name == 'c'
-    name = nameof(a.b.c, full=True)
+    name = nameof(a.b.c, vars_only=False)
     assert name == 'a.b.c'
 
     d = [a, a]
     with pytest.raises(
-            VarnameRetrievingError,
-            match='Can only retrieve full names of'
+            NonVariableArgumentError,
+            match='is not a variable or an attribute'
     ):
-        name = nameof(d[0].b, full=True)
+        name = nameof(d[0], vars_only=True)
 
     # we are not able to retreive full names without source code available
     with pytest.raises(
             VarnameRetrievingError,
             match=('Are you trying to call nameof from exec/eval')
     ):
-        eval('nameof(a.b, full=False)')
+        eval('nameof(a.b, a)')
 
 
 def test_nameof_from_stdin():
     code = ('from varname import nameof; '
             'x = lambda: 0; '
             'x.y = x; '
-            'print(nameof(x.y, full=False))')
+            'print(nameof(x.y, x))')
     p = subprocess.Popen([sys.executable],
                          stdin=subprocess.PIPE,
                          stdout=subprocess.PIPE,
@@ -69,7 +69,31 @@ def test_nameof_node_not_retrieved():
     source = ('from varname import nameof; '
               'x = lambda: 0; '
               'x.y = x; '
-              'print(nameof(x.y, full=False))')
+              'print(nameof(x.y, x))')
     code = compile(source, filename="<string2>", mode="exec")
     with pytest.raises(VarnameRetrievingError, match='Source code unavailable'):
         exec(code)
+
+    source = ('from varname import nameof; '
+              'x = lambda: 0; '
+              'x.y = x; '
+              'print(nameof(x.y, vars_only=True))')
+    code = compile(source, filename="<string3>", mode="exec")
+    with pytest.raises(
+            VarnameRetrievingError,
+            match="'nameof' can only be called with a single positional argument"):
+        exec(code)
+
+def test_nameof_wrapper():
+
+    def decorator(f):
+        def wrapper(var, *more_vars):
+            name, more = f(var, more_vars, frame=2)
+            return (name, *more)
+
+        return wrapper
+
+    wrap1 = decorator(nameof)
+    x = y = 1
+    name = wrap1(x, y)
+    assert name == ('x', 'y')

--- a/varname/__init__.py
+++ b/varname/__init__.py
@@ -10,4 +10,4 @@ from .utils import (
 )
 from .core import varname, nameof, will, argname
 
-__version__ = "0.6.1"
+__version__ = "0.6.2"

--- a/varname/helpers.py
+++ b/varname/helpers.py
@@ -150,21 +150,14 @@ def debug(var, *more_vars,
         merge: Whether merge all variables in one line or not
         repr: Print the value as `repr(var)`? otherwise `str(var)`
     """
-    if more_vars:
-        name, more_names = argname(
-            var, more_vars,
-            pos_only=True,
-            vars_only=vars_only,
-            func=debug
-        )
-        var_names = (name, *more_names)
-    else:
-        var_names = (argname(
-            var,
-            pos_only=True,
-            vars_only=vars_only,
-            func=debug
-        ), )
+    var_names = argname(
+        var, *more_vars,
+        pos_only=True,
+        vars_only=vars_only,
+        func=debug
+    )
+    if not isinstance(var_names, tuple):
+        var_names = (var_names, )
 
     values = (var, *more_vars)
     name_and_values = [

--- a/varname/ignore.py
+++ b/varname/ignore.py
@@ -261,7 +261,8 @@ class IgnoreList:
     @classmethod
     def create(cls,
                ignore: Optional[IgnoreType] = None,
-               ignore_lambda: bool = True) -> "IgnoreList":
+               ignore_lambda: bool = True,
+               ignore_varname: bool = True) -> "IgnoreList":
         """Create an IgnoreList object
 
         Args:
@@ -270,6 +271,8 @@ class IgnoreList:
                 A tuple of module (or filename) and qualified name
                 A function
                 A tuple of function and number of decorators
+            ignore_lambda: whether ignore lambda functions
+            ignore_varname: whether the calls from this package
 
         Returns:
             The IgnoreList object
@@ -279,9 +282,10 @@ class IgnoreList:
             ignore = [ignore]
 
         ignore_list = [
-            create_ignore_elem(sysconfig.get_python_lib(standard_lib=True)),
-            create_ignore_elem(sys.modules[__package__])
+            create_ignore_elem(sysconfig.get_python_lib(standard_lib=True))
         ]
+        if ignore_varname:
+            ignore_list.append(create_ignore_elem(sys.modules[__package__]))
         if ignore_lambda:
             ignore_list.append(create_ignore_elem((None, '*<lambda>')))
         for ignore_elem in ignore:

--- a/varname/utils.py
+++ b/varname/utils.py
@@ -282,7 +282,15 @@ def get_argument_sources(
         for argnode in node.keywords
     } if not pos_only else {}
     bound_args = signature.bind_partial(*arg_sources, **kwarg_sources)
-    return bound_args.arguments
+    argument_sources = bound_args.arguments
+    # see if *args and **kwargs have anything assigned
+    # if not, assign () and {} to them
+    for parameter in signature.parameters.values():
+        if parameter.kind == inspect.Parameter.VAR_POSITIONAL:
+            argument_sources.setdefault(parameter.name, ())
+        if parameter.kind == inspect.Parameter.VAR_KEYWORD:
+            argument_sources.setdefault(parameter.name, {})
+    return argument_sources
 
 def get_function_called_argname(
         frame: FrameType,


### PR DESCRIPTION
Changes:

- Remove argument `full` for `nameof`, use `vars_only` instead. When `vars_only=False`, source of the argument returned.
  ```python
  # before:
  nameof(a.b, full=True) # 'a.b'
  nameof(x[0], full=True) # unable to fetch
  # after (requires asttoken):
  nameof(a.b, vars_only=False) # 'a.b'
  nameof(x[0], vars_only=False) # 'x[0]'
  ```
- Add argument `frame` to `argname`, so that it can be wrapped.
  ```python
  def argname2(arg, *more_args):
      return argname(arg, *more_args, frame=2)
  ```
- Allow `argname` to fetch the source of variable keyword arguments (`**kwargs`), which will be an empty dict (`{}`) when no keyword arguments passed.
  ```python
  def func(a, **kwargs):
      return argname(a, kwargs)
  # before:
  func(x) # raises error
  # after:
  func(x) # returns ('x', {})
  ```
- Add argument `pos_only` to `argname` to only match the positional arguments
  ```python
  # before
  def func(a, b=1):
    return argname(a)
  func(x) # 'x'
  func(x, b=2) # error since 2 is not ast.Name

  # after
  def func(a, b=1):
    return argname(a, pos_only=True)
  func(x) # 'x'
  func(x, b=2) # 'x'
  ```
- Parse the arguments only if needed
  ```python
  # before
  def func(a, b):
    return argname(a)
  func(x, 1) # NonVariableArgumentError

  # after
  func(x, 1) # 'x'
  ```
- Allow variable positional arguments for `argname` so that `argname(*args)` is allowed
  ```python
  # before
  def func(arg, *args):
    return argname(arg, args) # *args not allowed
  x = y = 1
  func(x, y) # ('x', ('y', 1))

  # after
  def func(arg, *args):
    return argname(arg, *args)
  x = y = 1
  func(x, y) # ('x', 'y')
  ```
- Add `vars_only` (defaults to `False`) argument to `helpers.debug` so source of expression becomes available
  ```python
  a=1
  debug(a+a) # DEBUG: a+a=2
  ```