### PR TITLE
0.7.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
         if: ${{ always() }}
       - name: Upload Coverage
         run: |
-          export CODACY_PROJECT_TOKEN ${{ secrets.CODACY_PROJECT_TOKEN }}
+          export CODACY_PROJECT_TOKEN=${{ secrets.CODACY_PROJECT_TOKEN }}
           bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r .coverage.xml
         if: matrix.python-version == 3.7
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,11 +40,8 @@ jobs:
       - name: Upload Coverage
         if: matrix.python-version == 3.7
         run: |
-          export CODACY_PROJECT_TOKEN ${{ project-token }}
-          bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r ${{ coverage-reports }}
-        with:
-          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-          coverage-reports: .coverage.xml
+          export CODACY_PROJECT_TOKEN ${{ secrets.CODACY_PROJECT_TOKEN }}
+          bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r .coverage.xml
 
   deploy:
     needs: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,12 +37,12 @@ jobs:
           path: junit/test-results-${{ matrix.python-version }}.xml
         # Use always() to always run this step to publish test results when there are test failures
         if: ${{ always() }}
-      - name: Run codacy-coverage-reporter
-        uses: codacy/codacy-coverage-reporter-action@master
-        if: matrix.python-version == 3.7
+      - name: Upload Coverage
         with:
-          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-          coverage-reports: .coverage.xml
+          CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
+        run: |
+          bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r .coverage.xml
+        if: matrix.python-version == 3.7
 
   deploy:
     needs: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,9 @@
 name: Build and Deploy
 
-on: [push, pull_request]
+on:
+  push:
+  release:
+    types: [published]
 
 jobs:
 
@@ -21,11 +24,12 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install pylint=='2.8.*'
           python -m pip install poetry
+          poetry config virtualenvs.create false
           poetry install -v
       - name: Run pylint
         run: pylint varname
       - name: Test with pytest
-        run: poetry run pytest tests/ --junitxml=junit/test-results-${{ matrix.python-version }}.xml
+        run: pytest tests/ --junitxml=junit/test-results-${{ matrix.python-version }}.xml
       - name: Upload pytest test results
         uses: actions/upload-artifact@v2
         with:
@@ -43,10 +47,10 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    if: github.event_name == 'release'
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.9]
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python # Set Python version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,11 +37,12 @@ jobs:
           path: junit/test-results-${{ matrix.python-version }}.xml
         # Use always() to always run this step to publish test results when there are test failures
         if: ${{ always() }}
-      - name: Upload Coverage
+      - name: Run codacy-coverage-reporter
+        uses: codacy/codacy-coverage-reporter-action@master
         if: matrix.python-version == 3.7
-        run: |
-          export CODACY_PROJECT_TOKEN ${{ secrets.CODACY_PROJECT_TOKEN }}
-          bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r .coverage.xml
+        with:
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          coverage-reports: .coverage.xml
 
   deploy:
     needs: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,12 +39,12 @@ jobs:
         if: ${{ always() }}
       - name: Upload Coverage
         if: matrix.python-version == 3.7
-        with:
-          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-          coverage-reports: .coverage.xml
         run: |
           export CODACY_PROJECT_TOKEN ${{ project-token }}
           bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r ${{ coverage-reports }}
+        with:
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          coverage-reports: .coverage.xml
 
   deploy:
     needs: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pylint
+          python -m pip install pylint=='2.8.*'
           python -m pip install poetry
           poetry install -v
       - name: Run pylint

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,9 +38,8 @@ jobs:
         # Use always() to always run this step to publish test results when there are test failures
         if: ${{ always() }}
       - name: Upload Coverage
-        with:
-          CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
         run: |
+          export CODACY_PROJECT_TOKEN ${{ secrets.CODACY_PROJECT_TOKEN }}
           bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r .coverage.xml
         if: matrix.python-version == 3.7
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,12 +37,14 @@ jobs:
           path: junit/test-results-${{ matrix.python-version }}.xml
         # Use always() to always run this step to publish test results when there are test failures
         if: ${{ always() }}
-      - name: Run codacy-coverage-reporter
-        uses: codacy/codacy-coverage-reporter-action@master
-        if: matrix.python-version == 3.8
+      - name: Upload Coverage
+        if: matrix.python-version == 3.7
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
           coverage-reports: .coverage.xml
+        run: |
+          export CODACY_PROJECT_TOKEN ${{ project-token }}
+          bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r ${{ coverage-reports }}
 
   deploy:
     needs: build

--- a/.pylintrc
+++ b/.pylintrc
@@ -158,7 +158,8 @@ disable=print-statement,
         not-callable,
         unsubscriptable-object,
         unused-arguments,
-        fixme
+        fixme,
+        consider-using-dict-items
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/.pylintrc
+++ b/.pylintrc
@@ -159,7 +159,8 @@ disable=print-statement,
         unsubscriptable-object,
         unused-arguments,
         fixme,
-        consider-using-dict-items
+        consider-using-dict-items,
+        C0330
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ pip install -U varname
   - Retrieving names of variables a function/class call is assigned to from inside it, using `varname`.
   - Retrieving variable names directly, using `nameof`
   - Detecting next immediate attribute name, using `will`
-  - Fetching argument names/sources passed to a function using `argname`
+  - Fetching argument names/sources passed to a function using `argname2`
+    (`argname` is superseded by `argname2`)
 
 - Other helper APIs (built based on core features):
 
@@ -257,28 +258,28 @@ awesome.permit() # AttributeError: Should do something with AwesomeClass object
 awesome.permit().do() == 'I am doing!'
 ```
 
-### Fetching argument names/sources using `argname`
+### Fetching argument names/sources using `argname2`
 ```python
-from varname import argname
+from varname import argname2
 
 def func(a, b=1):
-    print(argname(a))
+    print(argname2('a'))
 
 x = y = z = 2
 func(x) # prints: x
 
 def func2(a, b=1):
-    print(argname(a, b))
+    print(argname2('a', 'b'))
 func2(y, b=x) # prints: ('y', 'x')
 
 # allow expressions
 def func3(a, b=1):
-    print(argname(a, b, vars_only=False))
+    print(argname2('a', 'b', vars_only=False))
 func3(x+y, y+x) # prints: ('x+y', 'y+x')
 
 # positional and keyword arguments
 def func4(*args, **kwargs):
-    print(argname(args[1], kwargs['c']))
+    print(argname2('args[1]', 'kwargs["c"]'))
 func4(y, x, c=z) # prints: ('x', 'z')
 ```
 
@@ -353,9 +354,9 @@ For example:
 [9]: https://img.shields.io/github/workflow/status/pwwang/python-varname/Build%20Docs?label=docs&style=flat-square
 [10]: https://img.shields.io/github/workflow/status/pwwang/python-varname/Build%20and%20Deploy?style=flat-square
 [11]: https://mybinder.org/v2/gh/pwwang/python-varname/dev?filepath=playground%2Fplayground.ipynb
-[12]: https://img.shields.io/codacy/grade/ed851ff47b194e3e9389b2a44d6f21da?style=flat-square
-[13]: https://app.codacy.com/manual/pwwang/python-varname/dashboard
-[14]: https://img.shields.io/codacy/coverage/ed851ff47b194e3e9389b2a44d6f21da?style=flat-square
+[12]: https://img.shields.io/codacy/grade/6fdb19c845f74c5c92056e88d44154f7?style=flat-square
+[13]: https://app.codacy.com/gh/pwwang/python-varname/dashboard
+[14]: https://img.shields.io/codacy/coverage/6fdb19c845f74c5c92056e88d44154f7?style=flat-square
 [15]: https://pwwang.github.io/python-varname/api/varname
 [16]: https://pwwang.github.io/python-varname/CHANGELOG/
 [17]: https://img.shields.io/gitter/room/pwwang/python-varname?style=flat-square

--- a/README.rst
+++ b/README.rst
@@ -27,14 +27,14 @@
    :target: https://img.shields.io/github/workflow/status/pwwang/python-varname/Build%20Docs?label=docs&style=flat-square
    :alt: Docs and API
  <https://pwwang.github.io/python-varname/api/varname>`_ `
-.. image:: https://img.shields.io/codacy/grade/ed851ff47b194e3e9389b2a44d6f21da?style=flat-square
-   :target: https://img.shields.io/codacy/grade/ed851ff47b194e3e9389b2a44d6f21da?style=flat-square
+.. image:: https://img.shields.io/codacy/grade/6fdb19c845f74c5c92056e88d44154f7?style=flat-square
+   :target: https://img.shields.io/codacy/grade/6fdb19c845f74c5c92056e88d44154f7?style=flat-square
    :alt: Codacy
- <https://app.codacy.com/manual/pwwang/python-varname/dashboard>`_ `
-.. image:: https://img.shields.io/codacy/coverage/ed851ff47b194e3e9389b2a44d6f21da?style=flat-square
-   :target: https://img.shields.io/codacy/coverage/ed851ff47b194e3e9389b2a44d6f21da?style=flat-square
+ <https://app.codacy.com/gh/pwwang/python-varname/dashboard>`_ `
+.. image:: https://img.shields.io/codacy/coverage/6fdb19c845f74c5c92056e88d44154f7?style=flat-square
+   :target: https://img.shields.io/codacy/coverage/6fdb19c845f74c5c92056e88d44154f7?style=flat-square
    :alt: Codacy coverage
- <https://app.codacy.com/manual/pwwang/python-varname/dashboard>`_
+ <https://app.codacy.com/gh/pwwang/python-varname/dashboard>`_
 `
 .. image:: https://img.shields.io/gitter/room/pwwang/python-varname?style=flat-square
    :target: https://img.shields.io/gitter/room/pwwang/python-varname?style=flat-square
@@ -63,7 +63,8 @@ Features
   * Retrieving names of variables a function/class call is assigned to from inside it, using ``varname``.
   * Retrieving variable names directly, using ``nameof``
   * Detecting next immediate attribute name, using ``will``
-  * Fetching argument names/sources passed to a function using ``argname``
+  * Fetching argument names/sources passed to a function using ``argname2``
+    (\ ``argname`` is superseded by ``argname2``\ )
 
 * 
   Other helper APIs (built based on core features):
@@ -324,31 +325,31 @@ Detecting next immediate attribute name
    awesome.permit() # AttributeError: Should do something with AwesomeClass object
    awesome.permit().do() == 'I am doing!'
 
-Fetching argument names/sources using ``argname``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Fetching argument names/sources using ``argname2``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: python
 
-   from varname import argname
+   from varname import argname2
 
    def func(a, b=1):
-       print(argname(a))
+       print(argname2('a'))
 
    x = y = z = 2
    func(x) # prints: x
 
    def func2(a, b=1):
-       print(argname(a, b))
+       print(argname2('a', 'b'))
    func2(y, b=x) # prints: ('y', 'x')
 
    # allow expressions
    def func3(a, b=1):
-       print(argname(a, b, vars_only=False))
+       print(argname2('a', 'b', vars_only=False))
    func3(x+y, y+x) # prints: ('x+y', 'y+x')
 
    # positional and keyword arguments
    def func4(*args, **kwargs):
-       print(argname(args[1], kwargs['c']))
+       print(argname2('args[1]', 'kwargs["c"]'))
    func4(y, x, c=z) # prints: ('x', 'z')
 
 Value wrapper

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,12 @@
+## v0.7.0
+- `ImproperUseError` is now independent of `VarnameRetrievingError`
+- Deprecate `argname`, superseded by `argname2`
+  ```python
+    >>> argname(a, b, ...) # before
+    >>> argname2('a', 'b', ...) # after
+  ```
+- Add `dispatch` argument to `argname`/`argment2` to be used for single-dispatched functions.
+
 ## v0.6.5
 - Add `sep` argument to `helpers.debug()`
 

--- a/playground/playground.ipynb
+++ b/playground/playground.ipynb
@@ -13,13 +13,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import functools\n",
     "from contextlib import contextmanager\n",
     "\n",
     "from varname import (\n",
-    "    varname, nameof, will, argname,\n",
+    "    varname, nameof, will, argname, argname2,\n",
     "    config, \n",
-    "    VarnameRetrievingError, QualnameNonUniqueError\n",
+    "    ImproperUseError, VarnameRetrievingError, QualnameNonUniqueError\n",
     ")\n",
     "from varname.helpers import Wrapper, register, debug\n",
     "\n",
@@ -61,14 +60,14 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "'f'"
       ]
      },
+     "execution_count": 2,
      "metadata": {},
-     "execution_count": 2
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -85,14 +84,14 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "'foo'"
       ]
      },
+     "execution_count": 3,
      "metadata": {},
-     "execution_count": 3
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -117,10 +116,16 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "1 func\n2 ['func']\n3 ['func', 'func']\n4 ('func',)\n5 ('func', 'func')\n6 func\n7 func\n"
+      "1 func\n",
+      "2 ['func']\n",
+      "3 ['func', 'func']\n",
+      "4 ('func',)\n",
+      "5 ('func', 'func')\n",
+      "6 func\n",
+      "7 func\n"
      ]
     }
    ],
@@ -164,14 +169,14 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "'f'"
       ]
      },
+     "execution_count": 5,
      "metadata": {},
-     "execution_count": 5
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -191,14 +196,14 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "'foo'"
       ]
      },
+     "execution_count": 6,
      "metadata": {},
-     "execution_count": 6
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -226,14 +231,14 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "'f'"
       ]
      },
+     "execution_count": 7,
      "metadata": {},
-     "execution_count": 7
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -260,14 +265,14 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "'f'"
       ]
      },
+     "execution_count": 8,
      "metadata": {},
-     "execution_count": 8
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -296,10 +301,18 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "VarnameRetrievingError(Failed to retrieve the variable name.) raised!\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/pwwang/github/python-varname/varname/ignore.py:175: MaybeDecoratedFunctionWarning: You asked varname to ignore function 'wrapper', which may be decorated. If it is not intended, you may need to ignore all intermediate frames with a tuple of the function and the number of its decorators.\n",
+      "  MaybeDecoratedFunctionWarning,\n"
      ]
     }
    ],
@@ -327,14 +340,14 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "'f'"
       ]
      },
+     "execution_count": 10,
      "metadata": {},
-     "execution_count": 10
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -368,21 +381,26 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stderr",
+     "output_type": "stream",
      "text": [
-      "[varname] DEBUG: Ignored by IgnoreModule('varname') [In 'varname' at /home/pwwang/github/python-varname/varname/core.py:87]\n[varname] DEBUG: Ignored by IgnoreModule('module_all_calls') [In 'func' at /home/pwwang/github/python-varname/playground/module_all_calls.py:6]\n[varname] DEBUG: Ignored by IgnoreModule('module_all_calls') [In 'func2' at /home/pwwang/github/python-varname/playground/module_all_calls.py:9]\n[varname] DEBUG: Ignored by IgnoreModule('module_all_calls') [In 'func3' at /home/pwwang/github/python-varname/playground/module_all_calls.py:12]\n[varname] DEBUG: Skipping (0 more to skip) [In 'func' at <ipython-input-11-8d0a7ff1a188>:4]\n[varname] DEBUG: Gotcha! [In '<module>' at <ipython-input-11-8d0a7ff1a188>:7]\n"
+      "[varname] DEBUG: Ignored by IgnoreModule('varname') [In 'varname' at /home/pwwang/github/python-varname/varname/core.py:99]\n",
+      "[varname] DEBUG: Ignored by IgnoreModule('module_all_calls') [In 'func' at /home/pwwang/github/python-varname/playground/module_all_calls.py:6]\n",
+      "[varname] DEBUG: Ignored by IgnoreModule('module_all_calls') [In 'func2' at /home/pwwang/github/python-varname/playground/module_all_calls.py:9]\n",
+      "[varname] DEBUG: Ignored by IgnoreModule('module_all_calls') [In 'func3' at /home/pwwang/github/python-varname/playground/module_all_calls.py:12]\n",
+      "[varname] DEBUG: Skipping (0 more to skip) [In 'func' at <ipython-input-11-8d0a7ff1a188>:4]\n",
+      "[varname] DEBUG: Gotcha! [In '<module>' at <ipython-input-11-8d0a7ff1a188>:7]\n"
      ]
     },
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "'f'"
       ]
      },
+     "execution_count": 11,
      "metadata": {},
-     "execution_count": 11
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -410,21 +428,25 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stderr",
+     "output_type": "stream",
      "text": [
-      "[varname] DEBUG: Ignored by IgnoreModule('varname') [In 'varname' at /home/pwwang/github/python-varname/varname/core.py:87]\n[varname] DEBUG: Ignored by IgnoreModuleQualname('module_glob_qualname', '_func*') [In '_func' at /home/pwwang/github/python-varname/playground/module_glob_qualname.py:6]\n[varname] DEBUG: Ignored by IgnoreModuleQualname('module_glob_qualname', '_func*') [In '_func2' at /home/pwwang/github/python-varname/playground/module_glob_qualname.py:9]\n[varname] DEBUG: Skipping (0 more to skip) [In 'func3' at /home/pwwang/github/python-varname/playground/module_glob_qualname.py:12]\n[varname] DEBUG: Gotcha! [In '<module>' at <ipython-input-12-07ea87f561cc>:4]\n"
+      "[varname] DEBUG: Ignored by IgnoreModule('varname') [In 'varname' at /home/pwwang/github/python-varname/varname/core.py:99]\n",
+      "[varname] DEBUG: Ignored by IgnoreModuleQualname('module_glob_qualname', '_func*') [In '_func' at /home/pwwang/github/python-varname/playground/module_glob_qualname.py:6]\n",
+      "[varname] DEBUG: Ignored by IgnoreModuleQualname('module_glob_qualname', '_func*') [In '_func2' at /home/pwwang/github/python-varname/playground/module_glob_qualname.py:9]\n",
+      "[varname] DEBUG: Skipping (0 more to skip) [In 'func3' at /home/pwwang/github/python-varname/playground/module_glob_qualname.py:12]\n",
+      "[varname] DEBUG: Gotcha! [In '<module>' at <ipython-input-12-07ea87f561cc>:4]\n"
      ]
     },
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "'f'"
       ]
      },
+     "execution_count": 12,
      "metadata": {},
-     "execution_count": 12
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -449,8 +471,8 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "QualnameNonUniqueError(Qualname 'func' in 'module_dual_qualnames' refers to multiple objects.) raised!\n"
      ]
@@ -476,21 +498,24 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stderr",
+     "output_type": "stream",
      "text": [
-      "[varname] DEBUG: Ignored by IgnoreModule('varname') [In 'varname' at /home/pwwang/github/python-varname/varname/core.py:87]\n[varname] DEBUG: Skipping (0 more to skip) [In 'func' at <ipython-input-14-d27bbc23b8df>:2]\n[varname] DEBUG: Ignored by IgnoreOnlyQualname(None, '*<lambda>') [In '<lambda>' at <ipython-input-14-d27bbc23b8df>:4]\n[varname] DEBUG: Gotcha! [In '<module>' at <ipython-input-14-d27bbc23b8df>:7]\n"
+      "[varname] DEBUG: Ignored by IgnoreModule('varname') [In 'varname' at /home/pwwang/github/python-varname/varname/core.py:99]\n",
+      "[varname] DEBUG: Skipping (0 more to skip) [In 'func' at <ipython-input-14-d27bbc23b8df>:2]\n",
+      "[varname] DEBUG: Ignored by IgnoreOnlyQualname(None, '*<lambda>') [In '<lambda>' at <ipython-input-14-d27bbc23b8df>:4]\n",
+      "[varname] DEBUG: Gotcha! [In '<module>' at <ipython-input-14-d27bbc23b8df>:7]\n"
      ]
     },
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "'f'"
       ]
      },
+     "execution_count": 14,
      "metadata": {},
-     "execution_count": 14
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -517,24 +542,24 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stderr",
+     "output_type": "stream",
      "text": [
-      "[varname] DEBUG: Ignored by IgnoreModule('varname') [In 'varname' at /home/pwwang/github/python-varname/varname/core.py:87]\n",
+      "[varname] DEBUG: Ignored by IgnoreModule('varname') [In 'varname' at /home/pwwang/github/python-varname/varname/core.py:99]\n",
       "[varname] DEBUG: Skipping (0 more to skip) [In '__init__' at <ipython-input-15-32fa2de0b542>:8]\n",
-      "[varname] DEBUG: Ignored by IgnoreModule('typing') [In '__call__' at /home/pwwang/miniconda3/lib/python3.7/typing.py:678]\n",
+      "[varname] DEBUG: Ignored by IgnoreStdlib('/home/pwwang/miniconda3/lib/python3.7/') [In '__call__' at /home/pwwang/miniconda3/lib/python3.7/typing.py:678]\n",
       "[varname] DEBUG: Gotcha! [In '<module>' at <ipython-input-15-32fa2de0b542>:11]\n"
      ]
     },
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "'foo'"
       ]
      },
+     "execution_count": 15,
      "metadata": {},
-     "execution_count": 15
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -559,14 +584,14 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "'foo'"
       ]
      },
+     "execution_count": 16,
      "metadata": {},
-     "execution_count": 16
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -593,14 +618,14 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "'f'"
       ]
      },
+     "execution_count": 17,
      "metadata": {},
-     "execution_count": 17
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -638,21 +663,25 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stderr",
+     "output_type": "stream",
      "text": [
-      "[varname] DEBUG: Ignored by IgnoreModule('varname') [In 'varname' at /home/pwwang/github/python-varname/varname/core.py:87]\n[varname] DEBUG: Ignored by IgnoreDecorated('wrapper', 2) [In 'func' at <ipython-input-18-e7a4675a5e8e>:4]\n[varname] DEBUG: Skipping (1 more to skip) [In 'wrapper' at <ipython-input-18-e7a4675a5e8e>:9]\n[varname] DEBUG: Skipping (0 more to skip) [In 'func3' at <ipython-input-18-e7a4675a5e8e>:18]\n[varname] DEBUG: Gotcha! [In '<module>' at <ipython-input-18-e7a4675a5e8e>:21]\n"
+      "[varname] DEBUG: Ignored by IgnoreModule('varname') [In 'varname' at /home/pwwang/github/python-varname/varname/core.py:99]\n",
+      "[varname] DEBUG: Ignored by IgnoreDecorated('wrapper', 2) [In 'func' at <ipython-input-18-e7a4675a5e8e>:4]\n",
+      "[varname] DEBUG: Skipping (1 more to skip) [In 'wrapper' at <ipython-input-18-e7a4675a5e8e>:9]\n",
+      "[varname] DEBUG: Skipping (0 more to skip) [In 'func3' at <ipython-input-18-e7a4675a5e8e>:18]\n",
+      "[varname] DEBUG: Gotcha! [In '<module>' at <ipython-input-18-e7a4675a5e8e>:21]\n"
      ]
     },
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "'f'"
       ]
      },
+     "execution_count": 18,
      "metadata": {},
-     "execution_count": 18
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -693,10 +722,15 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "1 (a, b) = ('a', 'b')\n2 (a, b) = ('a', 'b')\n3 a = ('a',)\n4 (a, b, c) = ('a', 'b', 'c')\n5 (a, b, x.c) = ('a', 'b', 'c')\nVarnameRetrievingError(Can only get name of a variable or attribute, not Starred(value=Name(id='b', ctx=Store()), ctx=Store())) raised!\n"
+      "1 (a, b) = ('a', 'b')\n",
+      "2 (a, b) = ('a', 'b')\n",
+      "3 a = ('a',)\n",
+      "4 (a, b, c) = ('a', 'b', 'c')\n",
+      "5 (a, b, x.c) = ('a', 'b', 'c')\n",
+      "ImproperUseError(Can only get name of a variable or attribute, not Starred(value=Name(id='b', ctx=Store()), ctx=Store())) raised!\n"
      ]
     }
    ],
@@ -722,7 +756,7 @@
     "a, (b, x.c) = function()\n",
     "print(5, '(a, b, x.c) =', (a, b, x.c))\n",
     "\n",
-    "with expect_raising(VarnameRetrievingError):\n",
+    "with expect_raising(ImproperUseError):\n",
     "    a, *b = function()"
    ]
   },
@@ -739,21 +773,21 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "VarnameRetrievingError(Failed to retrieve the variable name.) raised!\n"
      ]
     },
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "'None'"
       ]
      },
+     "execution_count": 20,
      "metadata": {},
-     "execution_count": 20
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -784,10 +818,18 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "f1 = 'f1', f2 = 'f1'\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/pwwang/github/python-varname/varname/core.py:122: MultiTargetAssignmentWarning: Multiple targets in assignment, variable name on the very left will be used.\n",
+      "  MultiTargetAssignmentWarning,\n"
      ]
     }
    ],
@@ -812,8 +854,8 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "x\n"
      ]
@@ -837,10 +879,13 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "x.a\nx.a.b\n('x.a', 'x.a.b')\nx.a()\n"
+      "x.a\n",
+      "x.a.b\n",
+      "('x.a', 'x.a.b')\n",
+      "x.a()\n"
      ]
     }
    ],
@@ -867,14 +912,14 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "'x'"
       ]
      },
+     "execution_count": 24,
      "metadata": {},
-     "execution_count": 24
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -897,10 +942,11 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "1\nAttributeError(Unable to access private attributes.) raised!\n"
+      "1\n",
+      "AttributeError(Unable to access private attributes.) raised!\n"
      ]
     }
    ],
@@ -934,32 +980,44 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "x\n('y', 'x')\n('x+y', 'y+x')\n('x', 'z')\n"
+      "x\n",
+      "x\n",
+      "('y', 'x')\n",
+      "('y', 'x')\n",
+      "('x+y', 'y+x')\n",
+      "('x+y', 'y+x')\n",
+      "('x', 'z')\n",
+      "('x', 'z')\n"
      ]
     }
    ],
    "source": [
+    "# argname is superseded by argname2\n",
     "def func(a, b=1):\n",
     "    print(argname(a))\n",
+    "    print(argname2('a'))\n",
     "\n",
     "x = y = z = 2\n",
     "func(x)\n",
     "\n",
     "def func2(a, b=1):\n",
     "    print(argname(a, b))\n",
+    "    print(argname2('a', 'b'))\n",
     "func2(y, b=x)\n",
     "\n",
     "# allow expressions\n",
     "def func3(a, b=1):\n",
     "    print(argname(a, b, vars_only=False))\n",
+    "    print(argname2('a', 'b', vars_only=False))\n",
     "func3(x+y, y+x)  \n",
     "\n",
     "# positional and keyword arguments\n",
     "def func4(*args, **kwargs):\n",
     "    print(argname(args[1], kwargs['c']))  \n",
+    "    print(argname2('args[1]', 'kwargs[c]'))  \n",
     "func4(y, x, c=z)\n",
     "\n"
    ]
@@ -970,23 +1028,23 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "x\n('x', 'y', 'x')\n"
+      "('x', 'y')\n"
      ]
     }
    ],
    "source": [
-    "# Wrap argname\n",
-    "def argname2(arg, *more_args):\n",
-    "    return argname(arg, *more_args, frame=2)\n",
+    "# It is easier to wrap argname2\n",
+    "# You don't have to use the exact signature\n",
+    "def argname3(*args):\n",
+    "    return argname2(*args, frame=2)\n",
     "\n",
-    "def func(*args):\n",
-    "    return argname2(*args)\n",
+    "def func(a, b):\n",
+    "    return argname3('a', 'b')\n",
     "\n",
-    "print(func(x))\n",
-    "print(func(x, y, x))"
+    "print(func(x, y))"
    ]
   },
   {
@@ -1009,10 +1067,13 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "<Wrapper (name='wrapped1', value=True)>\n<Wrapper (name='wrapped2', value={'a': 1})>\nTrue\nTrue\n"
+      "<Wrapper (name='wrapped1', value=True)>\n",
+      "<Wrapper (name='wrapped2', value={'a': 1})>\n",
+      "True\n",
+      "True\n"
      ]
     }
    ],
@@ -1043,10 +1104,13 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "<Wrapper (name='wrapped3', value=True)>\n<Wrapper (name='wrapped4', value={'a': 1})>\nTrue\nTrue\n"
+      "<Wrapper (name='wrapped3', value=True)>\n",
+      "<Wrapper (name='wrapped4', value={'a': 1})>\n",
+      "True\n",
+      "True\n"
      ]
     }
    ],
@@ -1084,14 +1148,14 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "'f'"
       ]
      },
+     "execution_count": 30,
      "metadata": {},
-     "execution_count": 30
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -1116,14 +1180,14 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "'foo'"
       ]
      },
+     "execution_count": 31,
      "metadata": {},
-     "execution_count": 31
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -1148,10 +1212,18 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "DEBUG: a='1'\nDEBUG: b='2'\nDEBUG: a='1'\nDEBUG: b='2'\nDEBUG: a='1', b='2'\nDEBUG: a=1, b=2\nDEBUG VARS: a='1', b='2'\nDEBUG: a+b='12'\n"
+      "DEBUG: a='1'\n",
+      "DEBUG: b='2'\n",
+      "DEBUG: a='1'\n",
+      "DEBUG: b='2'\n",
+      "DEBUG: a='1', b='2'\n",
+      "DEBUG: a=1, b=2\n",
+      "DEBUG VARS: a='1', b='2'\n",
+      "DEBUG: a+b='12'\n",
+      "DEBUG: a+b:'12'\n"
      ]
     }
    ],
@@ -1165,14 +1237,17 @@
     "debug(a, b, merge=True)\n",
     "debug(a, b, merge=True, repr=False)\n",
     "debug(a, b, merge=True, prefix='DEBUG VARS: ')\n",
-    "debug(a+b, vars_only=False)\n"
+    "debug(a+b, vars_only=False)\n",
+    "debug(a+b, sep=':', vars_only=False)\n"
    ]
   }
  ],
  "metadata": {
+  "interpreter": {
+   "hash": "c4cc73b080e063fcebb9afb794613be7caf4b26129562cba1382945a18cc49cc"
+  },
   "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
+   "display_name": "Python 3.7.8 64-bit ('base': conda)",
    "name": "python3"
   },
   "language_info": {
@@ -1185,7 +1260,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8-final"
+   "version": "3.7.8"
   },
   "orig_nbformat": 2
  },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "varname"
-version = "0.6.5"
+version = "0.7.0"
 description = "Dark magics about variable names in python."
 authors = [ "pwwang <pwwang@pwwang.com>",]
 license = "MIT"
@@ -23,3 +23,20 @@ pytest = "*"
 pytest-cov = "*"
 asttokens = "2.*"
 pure_eval = "0.*"
+
+[tool.pytest.ini_options]
+addopts = "-vv -W error::UserWarning --cov-config=.coveragerc --cov=varname --cov-report xml:.coverage.xml --cov-report term-missing"
+console_output_style = "progress"
+junit_family = "xunit1"
+
+[tool.mypy]
+ignore_missing_imports = true
+allow_redefinition = true
+disable_error_code = ["attr-defined", "no-redef"]
+show_error_codes = true
+strict_optional = false
+
+[tool.black]
+line-length = 80
+target-version = ['py37', 'py38', 'py39']
+include = '\.pyi?$'

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ if os.path.exists(readme_path):
 setup(
     long_description=readme,
     name='varname',
-    version='0.6.5',
+    version='0.7.0',
     description='Dark magics about variable names in python.',
     python_requires='==3.*,>=3.6.0',
     project_urls={"homepage": "https://github.com/pwwang/python-varname",

--- a/tests/test_argname.py
+++ b/tests/test_argname.py
@@ -274,3 +274,100 @@ def test_argname_singledispatched():
     p = q = 1.2
     out = add(p, q)
     assert out == ('p', 'q', 1)
+
+def test_argname2():
+
+    def func(a, b, c, d=4):
+        return argname2('c', 'b')
+
+    x = y = z = 1
+    names = func(x, y, z)
+    assert names == ('z', 'y')
+
+    def func2(a, b, c, d=4):
+        return argname2('b')
+
+    names2 = func2(x, y, z)
+    assert names2 == 'y'
+
+    def func3(e=1):
+        return argname2('e')
+
+    names3 = func3(z)
+    assert names3 == 'z'
+
+    def func4(a, b=1):
+        return argname2('a', 'b')
+    names4 = func4(y, b=x)
+    assert names4 == ('y', 'x')
+
+def test_argname2_func_na():
+    def func(a):
+        return argname2('a')
+
+    with pytest.raises(
+            VarnameRetrievingError,
+            match="Cannot retrieve the node where the function is called"
+    ):
+        exec('x=1; func(x)')
+
+def test_argname2_singledispatched():
+    # GH53
+    @singledispatch
+    def add(a, b):
+        aname = argname2('a', 'b', func=add.dispatch(object))
+        return aname + (1, ) # distinguish
+
+    @add.register(int)
+    def add_int(a, b):
+        aname = argname2('a', 'b', func=add_int)
+        return aname + (2, )
+
+    @add.register(str)
+    def add_str(a, b):
+        aname = argname2('a', 'b', dispatch=str)
+        return aname + (3, )
+
+    x = y = 1
+    out = add(x, y)
+    assert out == ('x', 'y', 2)
+
+    t = s = 'a'
+    out = add(t, s)
+    assert out == ('t', 's', 3)
+
+    p = q = 1.2
+    out = add(p, q)
+    assert out == ('p', 'q', 1)
+
+def test_argname2_nosucharg():
+
+    def func(a):
+        return argname2('x')
+
+    x = 1
+    with pytest.raises(ValueError):
+        func(x)
+
+def test_argname2_subscript_star():
+
+    def func1(*args, **kwargs):
+        return argname2('args[0]', 'kwargs[x]')
+
+    def func2(*args, **kwargs):
+        return argname2('*args')
+
+    x = y = 1
+    out = func1(y, x=x)
+    assert out == ('y', 'x')
+
+    out = func2(x, y)
+    assert out == ('x', 'y')
+
+def test_argname2_nonvar():
+
+    def func(x):
+        return argname2('x')
+
+    with pytest.raises(NonVariableArgumentError):
+        func(1)

--- a/tests/test_argname.py
+++ b/tests/test_argname.py
@@ -371,3 +371,12 @@ def test_argname2_nonvar():
 
     with pytest.raises(NonVariableArgumentError):
         func(1)
+
+def test_argname2_frame_error():
+
+    def func(x):
+        return argname2('x', frame=2)
+
+    with pytest.raises(VarnameRetrievingError):
+        func(1)
+

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,0 @@
-[pytest]
-addopts = -vv --cov-config=.coveragerc --cov=varname --cov-report xml:.coverage.xml --cov-report term-missing
-console_output_style = progress
-junit_family=xunit1

--- a/varname/__init__.py
+++ b/varname/__init__.py
@@ -7,8 +7,8 @@ from .utils import (
     QualnameNonUniqueError,
     NonVariableArgumentError,
     MultiTargetAssignmentWarning,
-    MaybeDecoratedFunctionWarning
+    MaybeDecoratedFunctionWarning,
 )
-from .core import varname, nameof, will, argname
+from .core import varname, nameof, will, argname, argname2
 
-__version__ = "0.6.5"
+__version__ = "0.7.0"

--- a/varname/core.py
+++ b/varname/core.py
@@ -1,7 +1,7 @@
 """Provide core features for varname"""
 import ast
 import warnings
-from typing import Optional, Tuple, Union, Any, Callable
+from typing import Optional, Tuple, Type, Union, Any, Callable
 
 from executing import Source
 
@@ -291,10 +291,11 @@ def nameof(var, *more_vars,
         pos_only=True
     )
 
-def argname(arg: Any, # pylint: disable=unused-argument
+def argname(arg: Any, # pylint: disable=unused-argument,too-many-branches
             *more_args: Any,
             # *, keyword-only argument, only available with python3.8+
             func: Optional[Callable] = None,
+            dispatch: Optional[Type] = None,
             frame: int = 1,
             vars_only: bool = True,
             pos_only: bool = False) -> Union[str, Tuple[str]]:
@@ -317,6 +318,8 @@ def argname(arg: Any, # pylint: disable=unused-argument
                 will be used. A warning will be shown since unwanted side
                 effects may happen in this case.
             You are encouraged to always pass the function explicitly.
+        dispatch: If a function is a single-dispatched function, you can
+            specify a type for it to dispatch the real function.
         frame: The frame where target function is called from this call.
             The intermediate calls will be the wrappers of this function.
             However, keep in mind that the wrappers must have the same
@@ -360,6 +363,9 @@ def argname(arg: Any, # pylint: disable=unused-argument
 
     if not func:
         func = get_function_called_argname(func_frame, func_node)
+
+    if dispatch:
+        func = func.dispatch(dispatch)
 
     # don't pass the target arguments so that we can cache the sources in
     # the same call. For example:

--- a/varname/core.py
+++ b/varname/core.py
@@ -537,13 +537,18 @@ def argname2(
     # >>> def func(a, b):
     # >>>   a_name = argname(a)
     # >>>   b_name = argname(b)
-    argument_sources = get_argument_sources(
-        Source.for_frame(func_frame),
-        func_node,
-        func,
-        vars_only=vars_only,
-        pos_only=False,
-    )
+    try:
+        argument_sources = get_argument_sources(
+            Source.for_frame(func_frame),
+            func_node,
+            func,
+            vars_only=vars_only,
+            pos_only=False,
+        )
+    except TypeError as terr:
+        raise VarnameRetrievingError(
+            "Have you specified the right `frame`?"
+        ) from terr
 
     out = [] # type: List[ArgSourceType]
     farg_star = False

--- a/varname/core.py
+++ b/varname/core.py
@@ -1,7 +1,8 @@
 """Provide core features for varname"""
 import ast
+import re
 import warnings
-from typing import Optional, Tuple, Type, Union, Any, Callable
+from typing import List, Tuple, Type, Union, Any, Callable
 
 from executing import Source
 
@@ -14,19 +15,21 @@ from .utils import (
     get_argument_sources,
     get_function_called_argname,
     parse_argname_subscript,
+    ArgSourceType,
     VarnameRetrievingError,
     ImproperUseError,
     NonVariableArgumentError,
-    MultiTargetAssignmentWarning
+    MultiTargetAssignmentWarning,
 )
 from .ignore import IgnoreList, IgnoreType
 
+
 def varname(
-        frame: int = 1,
-        ignore: Optional[IgnoreType] = None,
-        multi_vars: bool = False,
-        raise_exc: bool = True
-) -> Optional[Union[str, Tuple[Union[str, tuple]]]]:
+    frame: int = 1,
+    ignore: IgnoreType = None,
+    multi_vars: bool = False,
+    raise_exc: bool = True,
+) -> Union[str, Tuple[Union[str, Tuple], ...]]:
     """Get the name of the variable(s) that assigned by function call or
     class instantiation.
 
@@ -103,7 +106,7 @@ def varname(
     if not node:
         if raise_exc:
             raise VarnameRetrievingError(
-                'Failed to retrieve the variable name.'
+                "Failed to retrieve the variable name."
             )
         return None
 
@@ -113,15 +116,17 @@ def varname(
         # Need to actually check that there's just one
         # give warnings if: a = b = func()
         if len(node.targets) > 1:
-            warnings.warn("Multiple targets in assignment, variable name "
-                          "on the very left will be used.",
-                          MultiTargetAssignmentWarning)
+            warnings.warn(
+                "Multiple targets in assignment, variable name "
+                "on the very left will be used.",
+                MultiTargetAssignmentWarning,
+            )
         target = node.targets[0]
 
     names = node_name(target)
 
     if not isinstance(names, tuple):
-        names = (names, )
+        names = (names,)
 
     if multi_vars:
         return names
@@ -133,7 +138,8 @@ def varname(
 
     return names[0]
 
-def will(frame: int = 1, raise_exc: bool = True) -> Optional[str]:
+
+def will(frame: int = 1, raise_exc: bool = True) -> str:
     """Detect the attribute name right immediately after a function call.
 
     Examples:
@@ -195,10 +201,13 @@ def will(frame: int = 1, raise_exc: bool = True) -> Optional[str]:
     return node.attr
 
 
-def nameof(var, *more_vars,
-           # *, keyword only argument, supported with python3.8+
-           frame: int = 1,
-           vars_only: bool = True) -> Union[str, Tuple[str]]:
+def nameof(
+    var, # pylint: disable=unused-argument
+    *more_vars,
+    # *, keyword only argument, supported with python3.8+
+    frame: int = 1,
+    vars_only: bool = True,
+) -> Union[str, Tuple[str, ...]]:
     """Get the names of the variables passed in
 
     Examples:
@@ -247,8 +256,7 @@ def nameof(var, *more_vars,
     """
     # Frame is anyway used in get_node
     frameobj = IgnoreList.create(
-        ignore_lambda=False,
-        ignore_varname=False
+        ignore_lambda=False, ignore_varname=False
     ).get_frame(frame)
     node = get_node_by_frame(frameobj, raise_exc=True)
     if not node:
@@ -266,13 +274,13 @@ def nameof(var, *more_vars,
         # We are anyway raising exceptions, no worries about additional burden
         # of frame retrieval again
         source = frameobj.f_code.co_filename
-        if source == '<stdin>':
+        if source == "<stdin>":
             raise VarnameRetrievingError(
                 "Are you trying to call nameof in REPL/python shell? "
                 "In such a case, nameof can only be called with single "
                 "argument and no keyword arguments."
             )
-        if source == '<string>':
+        if source == "<string>":
             raise VarnameRetrievingError(
                 "Are you trying to call nameof from exec/eval? "
                 "In such a case, nameof can only be called with single "
@@ -283,23 +291,25 @@ def nameof(var, *more_vars,
             "a single variable, and argument `full` should not be specified."
         )
 
-    return argname(
-        var, *more_vars,
-        func=nameof,
-        frame=frame,
-        vars_only=vars_only,
-        pos_only=True
+    out = argname2(
+        "var", "*more_vars", func=nameof, frame=frame, vars_only=vars_only
     )
+    return out if more_vars else out[0] # type: ignore
 
-def argname(arg: Any, # pylint: disable=unused-argument,too-many-branches
-            *more_args: Any,
-            # *, keyword-only argument, only available with python3.8+
-            func: Optional[Callable] = None,
-            dispatch: Optional[Type] = None,
-            frame: int = 1,
-            vars_only: bool = True,
-            pos_only: bool = False) -> Union[str, Tuple[str]]:
+
+def argname( # pylint: disable=unused-argument,too-many-branches
+    arg: Any,
+    *more_args: Any,
+    # *, keyword-only argument, only available with python3.8+
+    func: Callable = None,
+    dispatch: Type = None,
+    frame: int = 1,
+    vars_only: bool = True,
+    pos_only: bool = False,
+) -> ArgSourceType:
     """Get the argument names/sources passed to a function
+
+    Superseded by `argname2()`
 
     Args:
         arg: Parameter of the function, used to map the argument passed to
@@ -319,7 +329,8 @@ def argname(arg: Any, # pylint: disable=unused-argument,too-many-branches
                 effects may happen in this case.
             You are encouraged to always pass the function explicitly.
         dispatch: If a function is a single-dispatched function, you can
-            specify a type for it to dispatch the real function.
+            specify a type for it to dispatch the real function. If this is
+            specified, expect `func` to be the generic function if provided.
         frame: The frame where target function is called from this call.
             The intermediate calls will be the wrappers of this function.
             However, keep in mind that the wrappers must have the same
@@ -341,10 +352,12 @@ def argname(arg: Any, # pylint: disable=unused-argument,too-many-branches
             Only variables and subscripts of variables are allow to be passed
             to this function.
     """
-    ignore_list = IgnoreList.create(
-        ignore_lambda=False,
-        ignore_varname=False
+    warnings.warn(
+        "`argname()` is superseded by `argname2()`, "
+        "and will be removed in v0.8.0",
+        DeprecationWarning,
     )
+    ignore_list = IgnoreList.create(ignore_lambda=False, ignore_varname=False)
     # where argname(...) is called
     argname_frame = ignore_list.get_frame(frame)
     argname_node = get_node_by_frame(argname_frame)
@@ -377,10 +390,10 @@ def argname(arg: Any, # pylint: disable=unused-argument,too-many-branches
         func_node,
         func,
         vars_only=vars_only,
-        pos_only=pos_only
+        pos_only=pos_only,
     )
 
-    ret = []
+    ret = [] # type: List[ArgSourceType]
     for argnode in argname_node.args:
         if not isinstance(argnode, (ast.Name, ast.Subscript, ast.Starred)):
             raise ValueError(
@@ -390,16 +403,16 @@ def argname(arg: Any, # pylint: disable=unused-argument,too-many-branches
 
         if isinstance(argnode, ast.Starred):
             if (
-                    not isinstance(argnode.value, ast.Name) or
-                    argnode.value.id not in argument_sources or
-                    not isinstance(argument_sources[argnode.value.id], tuple)
+                not isinstance(argnode.value, ast.Name)
+                or argnode.value.id not in argument_sources
+                or not isinstance(argument_sources[argnode.value.id], tuple)
             ):
                 posvar = argnode.value
-                posvar = getattr(posvar, 'id', posvar)
+                posvar = getattr(posvar, "id", posvar)
                 raise ValueError(
                     f"No such variable positional argument {posvar!r}"
                 )
-            ret.extend(argument_sources[argnode.value.id])
+            ret.extend(argument_sources[argnode.value.id]) # type: ignore
 
         elif isinstance(argnode, ast.Name):
             if argnode.id not in argument_sources:
@@ -414,26 +427,164 @@ def argname(arg: Any, # pylint: disable=unused-argument,too-many-branches
             if name not in argument_sources:
                 raise ValueError(f"{name!r} is not an argument.")
 
-            if (isinstance(subscript, int) and
-                    not isinstance(argument_sources[name], tuple)):
+            if isinstance(subscript, int) and not isinstance(
+                argument_sources[name], tuple
+            ):
                 raise ValueError(
                     f"{name!r} is not a positional argument "
                     "(*args, for example)."
                 )
-            if (isinstance(subscript, str) and
-                    not isinstance(argument_sources[name], dict)):
+            if isinstance(subscript, str) and not isinstance(
+                argument_sources[name], dict
+            ):
                 raise ValueError(
                     f"{name!r} is not a keyword argument "
                     "(**kwargs, for example)."
                 )
-            ret.append(argument_sources[name][subscript])
+            ret.append(argument_sources[name][subscript]) # type: ignore
 
     if vars_only:
         for source in ret:
             if isinstance(source, ast.AST):
                 raise NonVariableArgumentError(
-                    f'Argument {ast.dump(source)} is not a variable '
-                    'or an attribute.'
+                    f"Argument {ast.dump(source)} is not a variable "
+                    "or an attribute."
                 )
 
-    return ret[0] if not more_args else tuple(ret)
+    return ret[0] if not more_args else tuple(ret) # type: ignore
+
+
+def argname2(
+    arg: str,
+    *more_args: str,
+    # *, keyword-only argument, only available with python3.8+
+    func: Callable = None,
+    dispatch: Type = None,
+    frame: int = 1,
+    vars_only: bool = True,
+) -> ArgSourceType:
+    """Get the names/sources of arguments passed to a function.
+
+    Instead of passing the argument variables themselves to this function
+    (like `argname()` does), you should pass their names instead.
+
+    Args:
+        arg: and
+        *more_args: The names of the arguments that you want to retrieve
+            names/sources of.
+            You can also use subscripts to get parts of the results.
+            >>> def func(*args, **kwargs):
+            >>>     return argname2('args[0]', 'kwargs[x]') # no quote needed
+
+            Star argument is also allowed:
+            >>> def func(*args, x = 1):
+            >>>     return argname2('*args', 'x')
+            >>> a = b = c = 1
+            >>> func(a, b, x=c) # ('a', 'b', 'c')
+
+            Note the difference:
+            >>> def func(*args, x = 1):
+            >>>     return argname2('args', 'x')
+            >>> a = b = c = 1
+            >>> func(a, b, x=c) # (('a', 'b'), 'c')
+
+        func: The target function. If not provided, the AST node of the
+            function call will be used to fetch the function:
+            - If a variable (ast.Name) used as function, the `node.id` will
+                be used to get the function from `locals()` or `globals()`.
+            - If variable (ast.Name), attributes (ast.Attribute),
+                subscripts (ast.Subscript), and combinations of those and
+                literals used as function, `pure_eval` will be used to evaluate
+                the node
+            - If `pure_eval` is not installed or failed to evaluate, `eval`
+                will be used. A warning will be shown since unwanted side
+                effects may happen in this case.
+            You are very encouraged to always pass the function explicitly.
+        dispatch: If a function is a single-dispatched function, you can
+            specify a type for it to dispatch the real function. If this is
+            specified, expect `func` to be the generic function if provided.
+        frame: The frame where target function is called from this call.
+            Calls from python standard libraries are ignored.
+        vars_only: Require the arguments to be variables only.
+            If False, `asttokens` is required to retrieve the source.
+
+    Returns:
+        Scalar string if
+
+    """
+    ignore_list = IgnoreList.create(ignore_lambda=False, ignore_varname=False)
+    # where func(...) is called, skip the argname2() call
+    func_frame = ignore_list.get_frame(frame + 1)
+    func_node = get_node_by_frame(func_frame)
+    # Only do it when func_node are available
+    if not func_node:
+        # We can do something at bytecode level, when a single positional
+        # argument passed to both functions (argname and the target function)
+        # However, it's hard to ensure that there is only a single positional
+        # arguments passed to the target function, at bytecode level.
+        raise VarnameRetrievingError(
+            "Cannot retrieve the node where the function is called."
+        )
+
+    if not func:
+        func = get_function_called_argname(func_frame, func_node)
+
+    if dispatch:
+        func = func.dispatch(dispatch)
+
+    # don't pass the target arguments so that we can cache the sources in
+    # the same call. For example:
+    # >>> def func(a, b):
+    # >>>   a_name = argname(a)
+    # >>>   b_name = argname(b)
+    argument_sources = get_argument_sources(
+        Source.for_frame(func_frame),
+        func_node,
+        func,
+        vars_only=vars_only,
+        pos_only=False,
+    )
+
+    out = [] # type: List[ArgSourceType]
+    farg_star = False
+    for farg in (arg, *more_args):
+
+        farg_name = farg
+        farg_subscript = None # type: str | int
+        match = re.match(r"^([\w_]+)\[(.+)\]$", farg)
+        if match:
+            farg_name = match.group(1)
+            farg_subscript = match.group(2)
+            if farg_subscript.isdigit():
+                farg_subscript = int(farg_subscript)
+        else:
+            match = re.match(r"^\*([\w_]+)$", farg)
+            if match:
+                farg_name = match.group(1)
+                farg_star = True
+
+        if farg_name not in argument_sources:
+            raise ValueError(
+                f"{farg_name!r} is not a valid argument "
+                f"of {func.__qualname__!r}."
+            )
+
+        source = argument_sources[farg_name]
+        if isinstance(source, ast.AST):
+            raise NonVariableArgumentError(
+                f"Argument {ast.dump(source)} is not a variable "
+                "or an attribute."
+            )
+
+        if farg_subscript is not None:
+            out.append(source[farg_subscript]) # type: ignore
+        elif farg_star:
+            out.extend(source)
+        else:
+            out.append(source)
+
+    return (
+        out[0]
+        if not more_args and not farg_star
+        else tuple(out) # type: ignore
+    )

--- a/varname/ignore.py
+++ b/varname/ignore.py
@@ -25,7 +25,7 @@ from os import path
 from pathlib import Path
 from fnmatch import fnmatch
 from abc import ABC, abstractmethod
-from typing import List, Optional, Union
+from typing import List, Union
 from types import FrameType, ModuleType, FunctionType
 
 from executing import Source
@@ -38,7 +38,7 @@ from .utils import (
     attach_ignore_id_to_module,
     frame_matches_module_by_ignore_id,
     check_qualname_by_source,
-    debug_ignore_frame
+    debug_ignore_frame,
 )
 
 class IgnoreElem(ABC):
@@ -48,15 +48,15 @@ class IgnoreElem(ABC):
         """Define different attributes for subclasses"""
 
         def subclass_init(
-                self,
-                # IgnoreModule: ModuleType
-                # IgnoreFilename/IgnoreDirname: str
-                # IgnoreFunction: FunctionType
-                # IgnoreDecorated: FunctionType, int
-                # IgnoreModuleQualname/IgnoreFilenameQualname:
-                #   ModuleType/str, str
-                # IgnoreOnlyQualname: None, str
-                *ign_args: Optional[Union[str, int, ModuleType, FunctionType]]
+            self,
+            # IgnoreModule: ModuleType
+            # IgnoreFilename/IgnoreDirname: str
+            # IgnoreFunction: FunctionType
+            # IgnoreDecorated: FunctionType, int
+            # IgnoreModuleQualname/IgnoreFilenameQualname:
+            #   ModuleType/str, str
+            # IgnoreOnlyQualname: None, str
+            *ign_args: Union[str, int, ModuleType, FunctionType],
         ) -> None:
             """__init__ function for subclasses"""
             for attr, arg in zip(attrs, ign_args):
@@ -66,7 +66,7 @@ class IgnoreElem(ABC):
 
         # save it for __repr__
         cls.attrs = attrs
-        cls.__init__ = subclass_init
+        cls.__init__ = subclass_init # type: ignore
 
     def _post_init(self) -> None:
         """Setups after __init__"""
@@ -79,12 +79,15 @@ class IgnoreElem(ABC):
         """Representation of the element"""
         attr_values = (getattr(self, attr) for attr in self.__class__.attrs)
         # get __name__ if possible
-        attr_values = (repr(getattr(attr_value, '__name__', attr_value))
-                       for attr_value in attr_values)
-        attr_values = ', '.join(attr_values)
+        attr_values = (
+            repr(getattr(attr_value, "__name__", attr_value))
+            for attr_value in attr_values
+        )
+        attr_values = ", ".join(attr_values)
         return f"{self.__class__.__name__}({attr_values})"
 
-class IgnoreModule(IgnoreElem, attrs=['module']):
+
+class IgnoreModule(IgnoreElem, attrs=["module"]):
     """Ignore calls from a module or its submodules"""
 
     def _post_init(self) -> None:
@@ -94,22 +97,27 @@ class IgnoreModule(IgnoreElem, attrs=['module']):
         frame = frameinfos[frame_no].frame
         module = cached_getmodule(frame.f_code)
         if module:
-            return (module.__name__ == self.module.__name__ or
-                    module.__name__.startswith(f'{self.module.__name__}.'))
+            return (
+                module.__name__ == self.module.__name__
+                or module.__name__.startswith(f"{self.module.__name__}.")
+            )
 
         return frame_matches_module_by_ignore_id(frame, self.module)
 
-class IgnoreFilename(IgnoreElem, attrs=['filename']):
+
+class IgnoreFilename(IgnoreElem, attrs=["filename"]):
     """Ignore calls from a module by matching its filename"""
 
     def match(self, frame_no: int, frameinfos: List[inspect.FrameInfo]) -> bool:
         frame = frameinfos[frame_no].frame
 
         # in case of symbolic links
-        return (path.realpath(frame.f_code.co_filename) ==
-                path.realpath(self.filename))
+        return path.realpath(frame.f_code.co_filename) == path.realpath(
+            self.filename
+        )
 
-class IgnoreDirname(IgnoreElem, attrs=['dirname']):
+
+class IgnoreDirname(IgnoreElem, attrs=["dirname"]):
     """Ignore calls from modules inside a directory
 
     Currently used internally to ignore calls from standard libraries."""
@@ -119,10 +127,10 @@ class IgnoreDirname(IgnoreElem, attrs=['dirname']):
         # pylint: disable=attribute-defined-outside-init
 
         # Path object will turn into str here
-        self.dirname = path.realpath(self.dirname)
+        self.dirname = path.realpath(self.dirname) # type: str
 
         if not self.dirname.endswith(path.sep):
-            self.dirname = f'{self.dirname}{path.sep}'
+            self.dirname = f"{self.dirname}{path.sep}"
 
     def match(self, frame_no: int, frameinfos: List[inspect.FrameInfo]) -> bool:
         frame = frameinfos[frame_no].frame
@@ -130,7 +138,8 @@ class IgnoreDirname(IgnoreElem, attrs=['dirname']):
 
         return filename.startswith(self.dirname)
 
-class IgnoreStdlib(IgnoreDirname, attrs=['dirname']):
+
+class IgnoreStdlib(IgnoreDirname, attrs=["dirname"]):
     """Ignore standard libraries in sysconfig.get_python_lib(standard_lib=True)
 
     But we need to ignore 3rd-party packages under site-packages/.
@@ -138,37 +147,42 @@ class IgnoreStdlib(IgnoreDirname, attrs=['dirname']):
 
     def match(self, frame_no: int, frameinfos: List[inspect.FrameInfo]) -> bool:
         frame = frameinfos[frame_no].frame
-        third_party_lib = f'{self.dirname}site-packages{path.sep}'
+        third_party_lib = f"{self.dirname}site-packages{path.sep}"
         filename = path.realpath(frame.f_code.co_filename)
 
         return (
-            filename.startswith(self.dirname) and
+            filename.startswith(self.dirname)
+            and
             # Exclude 3rd-party libraries in site-packages
             not filename.startswith(third_party_lib)
         )
 
-class IgnoreFunction(IgnoreElem, attrs=['func']):
+
+class IgnoreFunction(IgnoreElem, attrs=["func"]):
     """Ignore a non-decorated function"""
+
     def _post_init(self) -> None:
         if (
-                # without functools.wraps
-                '<locals>' in self.func.__qualname__ or
-                self.func.__name__ != self.func.__code__.co_name
+            # without functools.wraps
+            "<locals>" in self.func.__qualname__
+            or self.func.__name__ != self.func.__code__.co_name
         ):
             warnings.warn(
-                f'You asked varname to ignore function {self.func.__name__!r}, '
-                'which may be decorated. If it is not intended, you may need '
-                'to ignore all intermediate frames with a tuple of '
-                'the function and the number of its decorators.',
-                MaybeDecoratedFunctionWarning
+                f"You asked varname to ignore function {self.func.__name__!r}, "
+                "which may be decorated. If it is not intended, you may need "
+                "to ignore all intermediate frames with a tuple of "
+                "the function and the number of its decorators.",
+                MaybeDecoratedFunctionWarning,
             )
 
     def match(self, frame_no: int, frameinfos: List[inspect.FrameInfo]) -> bool:
         frame = frameinfos[frame_no].frame
         return frame.f_code == self.func.__code__
 
-class IgnoreDecorated(IgnoreElem, attrs=['func', 'n_decor']):
+
+class IgnoreDecorated(IgnoreElem, attrs=["func", "n_decor"]):
     """Ignore a decorated function"""
+
     def match(self, frame_no: int, frameinfos: List[inspect.FrameInfo]) -> bool:
         try:
             frame = frameinfos[frame_no + self.n_decor].frame
@@ -177,19 +191,20 @@ class IgnoreDecorated(IgnoreElem, attrs=['func', 'n_decor']):
 
         return frame.f_code == self.func.__code__
 
-class IgnoreModuleQualname(IgnoreElem, attrs=['module', 'qualname']):
+
+class IgnoreModuleQualname(IgnoreElem, attrs=["module", "qualname"]):
     """Ignore calls by qualified name in the module"""
 
     def _post_init(self) -> None:
 
         attach_ignore_id_to_module(self.module)
         # check uniqueness of qualname
-        modfile = getattr(self.module, '__file__', None)
+        modfile = getattr(self.module, "__file__", None)
         if modfile is not None:
             check_qualname_by_source(
                 Source.for_filename(modfile, self.module.__dict__),
                 self.module.__name__,
-                self.qualname
+                self.qualname,
             )
 
     def match(self, frame_no: int, frameinfos: List[inspect.FrameInfo]) -> bool:
@@ -200,21 +215,18 @@ class IgnoreModuleQualname(IgnoreElem, attrs=['module', 'qualname']):
         if module and module != self.module:
             return False
 
-        if (
-                not module and
-                not frame_matches_module_by_ignore_id(frame, self.module)
+        if not module and not frame_matches_module_by_ignore_id(
+            frame, self.module
         ):
             return False
 
         source = Source.for_frame(frame)
         check_qualname_by_source(source, self.module.__name__, self.qualname)
 
-        return fnmatch(
-            source.code_qualname(frame.f_code),
-            self.qualname
-        )
+        return fnmatch(source.code_qualname(frame.f_code), self.qualname)
 
-class IgnoreFilenameQualname(IgnoreElem, attrs=['filename', 'qualname']):
+
+class IgnoreFilenameQualname(IgnoreElem, attrs=["filename", "qualname"]):
     """Ignore calls with given qualname in the module with the filename"""
 
     def match(self, frame_no: int, frameinfos: List[inspect.FrameInfo]) -> bool:
@@ -229,12 +241,10 @@ class IgnoreFilenameQualname(IgnoreElem, attrs=['filename', 'qualname']):
         source = Source.for_frame(frame)
         check_qualname_by_source(source, self.filename, self.qualname)
 
-        return fnmatch(
-            source.code_qualname(frame.f_code),
-            self.qualname
-        )
+        return fnmatch(source.code_qualname(frame.f_code), self.qualname)
 
-class IgnoreOnlyQualname(IgnoreElem, attrs=['_none', 'qualname']):
+
+class IgnoreOnlyQualname(IgnoreElem, attrs=["_none", "qualname"]):
     """Ignore calls that match the given qualname, across all frames."""
 
     def match(self, frame_no: int, frameinfos: List[inspect.FrameInfo]) -> bool:
@@ -242,48 +252,51 @@ class IgnoreOnlyQualname(IgnoreElem, attrs=['_none', 'qualname']):
 
         # module is None, check qualname only
         return fnmatch(
-            Source.for_frame(frame).code_qualname(frame.f_code),
-            self.qualname
+            Source.for_frame(frame).code_qualname(frame.f_code), self.qualname
         )
+
 
 def create_ignore_elem(ignore_elem: IgnoreElemType) -> IgnoreElem:
     """Create an ignore element according to the type"""
     if isinstance(ignore_elem, ModuleType):
-        return IgnoreModule(ignore_elem)
+        return IgnoreModule(ignore_elem)  # type: ignore
     if isinstance(ignore_elem, (Path, str)):
-        return (IgnoreDirname(ignore_elem)
-                if path.isdir(ignore_elem)
-                else IgnoreFilename(ignore_elem))
-    if hasattr(ignore_elem, '__code__'):
-        return IgnoreFunction(ignore_elem)
+        return (
+            IgnoreDirname(ignore_elem)  # type: ignore
+            if path.isdir(ignore_elem)
+            else IgnoreFilename(ignore_elem) # type: ignore
+        )
+    if hasattr(ignore_elem, "__code__"):
+        return IgnoreFunction(ignore_elem) # type: ignore
     if not isinstance(ignore_elem, tuple) or len(ignore_elem) != 2:
-        raise ValueError(f'Unexpected ignore item: {ignore_elem!r}')
+        raise ValueError(f"Unexpected ignore item: {ignore_elem!r}")
     # is tuple and len == 2
-    if (
-            hasattr(ignore_elem[0], '__code__') and
-            isinstance(ignore_elem[1], int)
-    ):
-        return IgnoreDecorated(*ignore_elem)
+    if hasattr(ignore_elem[0], "__code__") and isinstance(ignore_elem[1], int):
+        return IgnoreDecorated(*ignore_elem) # type: ignore
     # otherwise, the second element should be qualname
     if not isinstance(ignore_elem[1], str):
-        raise ValueError(f'Unexpected ignore item: {ignore_elem!r}')
+        raise ValueError(f"Unexpected ignore item: {ignore_elem!r}")
 
     if isinstance(ignore_elem[0], ModuleType):
-        return IgnoreModuleQualname(*ignore_elem)
+        return IgnoreModuleQualname(*ignore_elem) # type: ignore
     if isinstance(ignore_elem[0], (Path, str)):
-        return IgnoreFilenameQualname(*ignore_elem)
+        return IgnoreFilenameQualname(*ignore_elem) # type: ignore
     if ignore_elem[0] is None:
         return IgnoreOnlyQualname(*ignore_elem)
 
-    raise ValueError(f'Unexpected ignore item: {ignore_elem!r}')
+    raise ValueError(f"Unexpected ignore item: {ignore_elem!r}")
+
 
 class IgnoreList:
     """The ignore list to match the frames to see if they should be ignored"""
+
     @classmethod
-    def create(cls,
-               ignore: Optional[IgnoreType] = None,
-               ignore_lambda: bool = True,
-               ignore_varname: bool = True) -> "IgnoreList":
+    def create(
+        cls,
+        ignore: IgnoreType = None,
+        ignore_lambda: bool = True,
+        ignore_varname: bool = True,
+    ) -> "IgnoreList":
         """Create an IgnoreList object
 
         Args:
@@ -303,23 +316,25 @@ class IgnoreList:
             ignore = [ignore]
 
         ignore_list = [
-            IgnoreStdlib(sysconfig.get_python_lib(standard_lib=True))
-        ]
+            IgnoreStdlib( # type: ignore
+                sysconfig.get_python_lib(standard_lib=True)
+            )
+        ] # type: List[IgnoreElem]
         if ignore_varname:
             ignore_list.append(create_ignore_elem(sys.modules[__package__]))
         if ignore_lambda:
-            ignore_list.append(create_ignore_elem((None, '*<lambda>')))
+            ignore_list.append(create_ignore_elem((None, "*<lambda>")))
         for ignore_elem in ignore:
             ignore_list.append(create_ignore_elem(ignore_elem))
 
-        return cls(ignore_list)
+        return cls(ignore_list) # type: ignore
 
     def __init__(self, ignore_list: List[IgnoreElemType]) -> None:
         self.ignore_list = ignore_list
 
-    def nextframe_to_check(self,
-                           frame_no: int,
-                           frameinfos: List[inspect.FrameInfo]) -> int:
+    def nextframe_to_check(
+        self, frame_no: int, frameinfos: List[inspect.FrameInfo]
+    ) -> int:
         """Find the next frame to check
 
         In modst cases, the next frame to check is the next adjacent frame.
@@ -334,15 +349,17 @@ class IgnoreList:
             A number for Next `N`th frame to check. 0 if no frame matched.
         """
         for ignore_elem in self.ignore_list:
-            matched = ignore_elem.match(frame_no, frameinfos)
+            matched = ignore_elem.match(frame_no, frameinfos) # type: ignore
             if matched and isinstance(ignore_elem, IgnoreDecorated):
-                debug_ignore_frame(f'Ignored by {ignore_elem!r}',
-                                   frameinfos[frame_no])
+                debug_ignore_frame(
+                    f"Ignored by {ignore_elem!r}", frameinfos[frame_no]
+                )
                 return ignore_elem.n_decor + 1
 
             if matched:
-                debug_ignore_frame(f'Ignored by {ignore_elem!r}',
-                                   frameinfos[frame_no])
+                debug_ignore_frame(
+                    f"Ignored by {ignore_elem!r}", frameinfos[frame_no]
+                )
                 return 1
         return 0
 
@@ -373,15 +390,17 @@ class IgnoreList:
 
                 frame_no -= 1
                 if frame_no == 0:
-                    debug_ignore_frame('Gotcha!', frames[i])
+                    debug_ignore_frame("Gotcha!", frames[i])
                     return frames[i].frame
 
                 debug_ignore_frame(
-                    f'Skipping ({frame_no - 1} more to skip)',
-                    frames[i]
+                    f"Skipping ({frame_no - 1} more to skip)", frames[i]
                 )
                 i += 1
 
         except Exception as exc:
             from .utils import VarnameRetrievingError
+
             raise VarnameRetrievingError from exc
+
+        return None # pragma: no cover

--- a/varname/utils.py
+++ b/varname/utils.py
@@ -18,7 +18,7 @@ from os import path
 from pathlib import Path
 from functools import lru_cache
 from types import ModuleType, FunctionType, CodeType, FrameType
-from typing import Optional, Tuple, Union, List, MutableMapping, Callable
+from typing import Tuple, Union, List, Mapping, Callable
 
 from executing import Source
 
@@ -32,48 +32,50 @@ IgnoreElemType = Union[
     # the module (filename) and qualname
     # If module is None, then all qualname matches the 2nd element
     # will be ignored. Used to ignore <lambda> internally
-    Tuple[Optional[Union[ModuleType, str]], str],
+    Tuple[Union[ModuleType, str], str],
     # Function and number of its decorators
-    Tuple[FunctionType, int]
+    Tuple[FunctionType, int],
 ]
 IgnoreType = Union[IgnoreElemType, List[IgnoreElemType]]
 
-MODULE_IGNORE_ID_NAME = '__varname_ignore_id__'
+ArgSourceType = Union[ast.AST, str]
+ArgSourceType = Union[ArgSourceType, Tuple[ArgSourceType, ...]]
+ArgSourceType = Union[ArgSourceType, Mapping[str, ArgSourceType]]
 
-class config: # pylint: disable=invalid-name
+MODULE_IGNORE_ID_NAME = "__varname_ignore_id__"
+
+
+class config:  # pylint: disable=invalid-name
     """Global configurations for varname
 
     Attributes:
         debug: Show debug information for frames being ignored
     """
+
     debug = False
+
 
 class VarnameRetrievingError(Exception):
     """When failed to retrieve the varname"""
+
 
 class QualnameNonUniqueError(Exception):
     """When a qualified name is used as an ignore element but references to
     multiple objects in a module"""
 
+
 class NonVariableArgumentError(Exception):
     """When vars_only is True but try to retrieve name of
     a non-variable argument"""
 
-class ImproperUseError(VarnameRetrievingError):
+
+class ImproperUseError(Exception):
     """When varname() is improperly used"""
-    def __init__(self, message: str) -> None:
-        message = (
-            f"{message}\n\n"
-            "(Warning: `ImproperUseError` is a subclass of "
-            "`VarnameRetrievingError` for now for backward compatibility, "
-            "so you can still use `VarnameRetrievingError` to catch it. "
-            "But it will be independent of `VarnameRetrievingError` "
-            "in the future.)"
-        )
-        super().__init__(message)
+
 
 class MaybeDecoratedFunctionWarning(Warning):
     """When a suspecious decorated function used as ignore function directly"""
+
 
 class MultiTargetAssignmentWarning(Warning):
     """When varname tries to retrieve variable name in
@@ -85,12 +87,13 @@ def cached_getmodule(codeobj: CodeType):
     """Cached version of inspect.getmodule"""
     return inspect.getmodule(codeobj)
 
+
 def get_node(
-        frame: int,
-        ignore: Optional[IgnoreType] = None,
-        raise_exc: bool = True,
-        ignore_lambda: bool = True
-) -> Optional[ast.AST]:
+    frame: int,
+    ignore: IgnoreType = None,
+    raise_exc: bool = True,
+    ignore_lambda: bool = True,
+) -> ast.AST:
     """Try to get node from the executing object.
 
     This can fail when a frame is failed to retrieve.
@@ -100,18 +103,19 @@ def get_node(
     When the node can not be retrieved, try to return the first statement.
     """
     from .ignore import IgnoreList
+
     ignore = IgnoreList.create(ignore, ignore_lambda=ignore_lambda)
     try:
-        frame = ignore.get_frame(frame)
+        frameobj = ignore.get_frame(frame)
     except VarnameRetrievingError:
         return None
 
-    return get_node_by_frame(frame, raise_exc)
+    return get_node_by_frame(frameobj, raise_exc)
+
 
 def get_node_by_frame(
-        frame: FrameType,
-        raise_exc: bool = True
-) -> Optional[ast.AST]:
+    frame: FrameType, raise_exc: bool = True
+) -> ast.AST:
     """Get the node by frame, raise errors if possible"""
     exect = Source.executing(frame)
 
@@ -127,16 +131,18 @@ def get_node_by_frame(
 
     return None
 
-def lookfor_parent_assign(node: ast.AST) -> Optional[ast.Assign]:
+
+def lookfor_parent_assign(node: ast.AST) -> Union[ast.Assign, ast.AnnAssign]:
     """Look for an ast.Assign node in the parents"""
-    while hasattr(node, 'parent'):
+    while hasattr(node, "parent"):
         node = node.parent
 
         if isinstance(node, (ast.AnnAssign, ast.Assign)):
             return node
     return None
 
-def node_name(node: ast.AST) -> Optional[Union[str, Tuple[Union[str, tuple]]]]:
+
+def node_name(node: ast.AST) -> Union[str, Tuple[Union[str, Tuple], ...]]:
     """Get the node node name.
 
     Raises ImproperUseError when failed
@@ -153,6 +159,7 @@ def node_name(node: ast.AST) -> Optional[Union[str, Tuple[Union[str, tuple]]]]:
         f"not {ast.dump(node)}"
     )
 
+
 @lru_cache()
 def bytecode_nameof(code: CodeType, offset: int) -> str:
     """Cached Bytecode version of nameof
@@ -163,16 +170,13 @@ def bytecode_nameof(code: CodeType, offset: int) -> str:
     manipulated to run but sourcecode is not available.
     """
     instructions = list(dis.get_instructions(code))
-    (current_instruction_index, current_instruction), = (
+    ((current_instruction_index, current_instruction),) = (
         (index, instruction)
         for index, instruction in enumerate(instructions)
         if instruction.offset == offset
     )
 
-    if current_instruction.opname in (
-            "CALL_FUNCTION_EX",
-            "CALL_FUNCTION_KW"
-    ):
+    if current_instruction.opname in ("CALL_FUNCTION_EX", "CALL_FUNCTION_KW"):
         raise VarnameRetrievingError(
             "'nameof' can only be called with a single positional argument "
             "when source code is not avaiable."
@@ -181,9 +185,7 @@ def bytecode_nameof(code: CodeType, offset: int) -> str:
     if current_instruction.opname not in ("CALL_FUNCTION", "CALL_METHOD"):
         raise VarnameRetrievingError("Did you call 'nameof' in a weird way?")
 
-    name_instruction = instructions[
-        current_instruction_index - 1
-    ]
+    name_instruction = instructions[current_instruction_index - 1]
 
     if not name_instruction.opname.startswith("LOAD_"):
         raise VarnameRetrievingError("Argument must be a variable or attribute")
@@ -198,6 +200,7 @@ def bytecode_nameof(code: CodeType, offset: int) -> str:
 
     return name
 
+
 def attach_ignore_id_to_module(module: ModuleType) -> None:
     """Attach the ignore id to module
 
@@ -209,30 +212,28 @@ def attach_ignore_id_to_module(module: ModuleType) -> None:
     the module. Since this probably means the source is not avaiable and
     `inspect.getmodule` would not work
     """
-    module_file = getattr(module, '__file__', None)
+    module_file = getattr(module, "__file__", None)
     if module_file is not None and path.isfile(module_file):
         return
     # or it's already been set
     if hasattr(module, MODULE_IGNORE_ID_NAME):
         return
 
-    setattr(module, MODULE_IGNORE_ID_NAME, f'<varname-ignore-{id(module)})')
+    setattr(module, MODULE_IGNORE_ID_NAME, f"<varname-ignore-{id(module)})")
 
 
 def frame_matches_module_by_ignore_id(
-        frame: FrameType,
-        module: ModuleType
+    frame: FrameType, module: ModuleType
 ) -> bool:
     """Check if the frame is from the module by ignore id"""
     ignore_id_attached = getattr(module, MODULE_IGNORE_ID_NAME, object())
     ignore_id_from_frame = frame.f_globals.get(MODULE_IGNORE_ID_NAME, object())
     return ignore_id_attached == ignore_id_from_frame
 
+
 @lru_cache()
 def check_qualname_by_source(
-        source: Source,
-        modname: str,
-        qualname: str
+    source: Source, modname: str, qualname: str
 ) -> None:
     """Check if a qualname in module is unique"""
     if not source.tree:
@@ -245,9 +246,10 @@ def check_qualname_by_source(
             f"{modname!r} refers to multiple objects."
         )
 
+
 def debug_ignore_frame(
-        msg: str,
-        frameinfo: Optional[inspect.FrameInfo] = None
+    msg: str,
+    frameinfo: inspect.FrameInfo = None
 ) -> None:
     """Print the debug message for a given frame info object
 
@@ -258,13 +260,16 @@ def debug_ignore_frame(
     if not config.debug:
         return
     if frameinfo is not None:
-        msg = (f'{msg} [In {frameinfo.function!r} at '
-               f'{frameinfo.filename}:{frameinfo.lineno}]')
-    sys.stderr.write(f'[{__package__}] DEBUG: {msg}\n')
+        msg = (
+            f"{msg} [In {frameinfo.function!r} at "
+            f"{frameinfo.filename}:{frameinfo.lineno}]"
+        )
+    sys.stderr.write(f"[{__package__}] DEBUG: {msg}\n")
 
-def argnode_source(source: Source,
-                   node: ast.AST,
-                   vars_only: bool) -> Union[str, ast.AST]:
+
+def argnode_source(
+    source: Source, node: ast.AST, vars_only: bool
+) -> Union[str, ast.AST]:
     """Get the source of an argument node
 
     Args:
@@ -279,22 +284,25 @@ def argnode_source(source: Source,
     """
     if vars_only:
         return (
-            node.id if isinstance(node, ast.Name)
-            else node.attr if isinstance(node, ast.Attribute)
+            node.id
+            if isinstance(node, ast.Name)
+            else node.attr
+            if isinstance(node, ast.Attribute)
             else node
         )
 
     # requires asttokens
     return source.asttokens().get_text(node)
 
+
 @lru_cache()
 def get_argument_sources(
-        source: Source,
-        node: ast.Call,
-        func: Callable,
-        vars_only: bool,
-        pos_only: bool
-) -> MutableMapping[str, Union[ast.AST, str]]:
+    source: Source,
+    node: ast.Call,
+    func: Callable,
+    vars_only: bool,
+    pos_only: bool,
+) -> Mapping[str, ArgSourceType]:
     """Get the sources for argument from an ast.Call node
 
     >>> def func(a, b, c, d=4):
@@ -309,14 +317,17 @@ def get_argument_sources(
     signature = inspect.signature(func, follow_wrapped=False)
     # func(y, x, c=z)
     # ['y', 'x'], {'c': 'z'}
-    arg_sources = [argnode_source(source, argnode, vars_only)
-                   for argnode in node.args]
-    kwarg_sources = {
-        argnode.arg: argnode_source(source,
-                                    argnode.value,
-                                    vars_only)
-        for argnode in node.keywords
-    } if not pos_only else {}
+    arg_sources = [
+        argnode_source(source, argnode, vars_only) for argnode in node.args
+    ]
+    kwarg_sources = (
+        {
+            argnode.arg: argnode_source(source, argnode.value, vars_only)
+            for argnode in node.keywords
+        }
+        if not pos_only
+        else {}
+    )
     bound_args = signature.bind_partial(*arg_sources, **kwarg_sources)
     argument_sources = bound_args.arguments
     # see if *args and **kwargs have anything assigned
@@ -328,10 +339,8 @@ def get_argument_sources(
             argument_sources.setdefault(parameter.name, {})
     return argument_sources
 
-def get_function_called_argname(
-        frame: FrameType,
-        node: ast.AST
-) -> Callable:
+
+def get_function_called_argname(frame: FrameType, node: ast.AST) -> Callable:
     """Get the function who called argname"""
     # We need node to be ast.Call
     if not isinstance(node, ast.Call):
@@ -343,10 +352,9 @@ def get_function_called_argname(
     # variable
     if isinstance(node.func, ast.Name):
         func = frame.f_locals.get(
-            node.func.id,
-            frame.f_globals.get(node.func.id)
+            node.func.id, frame.f_globals.get(node.func.id)
         )
-        if func is None: # pragma: no cover
+        if func is None:  # pragma: no cover
             # not sure how it would happen but in case
             raise VarnameRetrievingError(
                 f"Cannot retrieve the function by {node.func.id!r}."
@@ -377,9 +385,10 @@ def get_function_called_argname(
         "passing the function to 'argname' explicitly."
     )
     expr = ast.Expression(node.func)
-    code = compile(expr, '<ast-call>', 'eval')
+    code = compile(expr, "<ast-call>", "eval")
     # pylint: disable=eval-used
     return eval(code, frame.f_globals, frame.f_locals)
+
 
 def parse_argname_subscript(node: ast.Subscript):
     """Parse the ast.Subscript node passed to argname
@@ -395,14 +404,16 @@ def parse_argname_subscript(node: ast.Subscript):
     if not isinstance(name, ast.Name):
         raise ValueError(f"Expect {ast.dump(name)} to be a variable.")
 
-    subscript = node.slice
+    subscript = node.slice # type: ast.AST
     if isinstance(subscript, ast.Index):
         subscript = subscript.value
     if not isinstance(subscript, (ast.Str, ast.Num, ast.Constant)):
         raise ValueError(f"Expect {ast.dump(subscript)} to be a constant.")
 
-    subscript = getattr(subscript, 'value', subscript) # ast.Index, ast.Constant
-    subscript = getattr(subscript, 'n', subscript) # ast.Num
-    subscript = getattr(subscript, 's', subscript) # ast.Str
+    subscript = getattr(
+        subscript, "value", subscript
+    )  # ast.Index, ast.Constant
+    subscript = getattr(subscript, "n", subscript)  # ast.Num
+    subscript = getattr(subscript, "s", subscript)  # ast.Str
 
     return name.id, subscript


### PR DESCRIPTION
- `ImproperUseError` is now independent of `VarnameRetrievingError` (Close #49)
- Deprecate `argname`, superseded by `argname2`
  ```python
    >>> argname(a, b, ...) # before
    >>> argname2('a', 'b', ...) # after
  ```
- Add `dispatch` argument to `argname`/`argment2` to be used for single-dispatched functions.

Why supersed `argname()` by `argname2()`?
1. No need to retrieve the `argname(...)` call anymore
2. Easier to wrap `argname2()`:
    ```python
    # It is easier to wrap argname2
    # You don't have to use the exact signature
    def argname3(*args):
        return argname2(*args, frame=2)

    def func(a, b):
        return argname3('a', 'b')
    
    x = y = 1
    print(func(x, y)) # ('x', 'y')
    ```
3. `frame` argument is now specific to where the target function is called, not connected with `argname2(...)` call anymore.