### PR TITLE
Add `direct` option to varname, support walrus operator

### DIFF
--- a/tests/named_expr.py
+++ b/tests/named_expr.py
@@ -1,0 +1,8 @@
+"""Contains code that is only importable with Python >= 3.8."""
+
+from varname import varname
+
+def function():
+    return varname(named_expr=True), varname(named_expr=False)
+
+a = [b := function(), c := function()]

--- a/tests/test_varname.py
+++ b/tests/test_varname.py
@@ -140,6 +140,26 @@ def test_raise_exc():
     name += str(get_name(False))
     assert name == '0None'
 
+def test_direct():
+
+    def foo(x):
+        return x
+
+    def function():
+        return varname(direct=True)
+
+    func = function()
+    assert func == 'func'
+
+    with pytest.raises(VarnameRetrievingError):
+        func = function() + "_"
+
+    with pytest.raises(VarnameRetrievingError):
+        func = foo(function())
+
+    with pytest.raises(VarnameRetrievingError):
+        func = [function()]
+
 def test_multiple_targets():
 
     def function():

--- a/tests/test_varname.py
+++ b/tests/test_varname.py
@@ -160,6 +160,14 @@ def test_direct():
     with pytest.raises(VarnameRetrievingError):
         func = [function()]
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 8),
+    reason="named expressions require Python >= 3.8"
+)
+def test_named_expr():
+    from .named_expr import a
+    assert a == [("b", "a"), ("c", "a")]
+
 def test_multiple_targets():
 
     def function():

--- a/varname/core.py
+++ b/varname/core.py
@@ -29,6 +29,7 @@ def varname(
     ignore: IgnoreType = None,
     multi_vars: bool = False,
     raise_exc: bool = True,
+    direct: bool = False,
 ) -> Union[str, Tuple[Union[str, Tuple], ...]]:
     """Get the name of the variable(s) that assigned by function call or
     class instantiation.
@@ -72,6 +73,8 @@ def varname(
             Note that set this to `False` will not supress the exception when
             the use of `varname` is improper (i.e. multiple variables on
             LHS with `multi_vars` is `False`). See `Raises/ImproperUseError`.
+        direct: Whether to only return the variable name if the result of
+            the call is assigned to it directly.
 
     Returns:
         The variable name, or `None` when `raise_exc` is `False` and
@@ -102,7 +105,8 @@ def varname(
             raise VarnameRetrievingError("Unable to retrieve the ast node.")
         return None
 
-    node = lookfor_parent_assign(node)
+    node = lookfor_parent_assign(node, direct=direct)
+
     if not node:
         if raise_exc:
             raise VarnameRetrievingError(

--- a/varname/utils.py
+++ b/varname/utils.py
@@ -132,13 +132,19 @@ def get_node_by_frame(
     return None
 
 
-def lookfor_parent_assign(node: ast.AST) -> Union[ast.Assign, ast.AnnAssign]:
+def lookfor_parent_assign(
+    node: ast.AST,
+    direct: bool = False,
+) -> Union[ast.Assign, ast.AnnAssign]:
     """Look for an ast.Assign node in the parents"""
     while hasattr(node, "parent"):
         node = node.parent
 
         if isinstance(node, (ast.AnnAssign, ast.Assign)):
             return node
+
+        if direct:
+            break
     return None
 
 

--- a/varname/utils.py
+++ b/varname/utils.py
@@ -41,6 +41,11 @@ IgnoreType = Union[IgnoreElemType, List[IgnoreElemType]]
 ArgSourceType = Union[ast.AST, str]
 ArgSourceType = Union[ArgSourceType, Tuple[ArgSourceType, ...]]
 ArgSourceType = Union[ArgSourceType, Mapping[str, ArgSourceType]]
+AssignType = (
+    Union[ast.Assign, ast.AnnAssign, ast.NamedExpr]
+    if sys.version_info >= (3, 8)
+    else Union[ast.Assign, ast.AnnAssign]
+)
 
 MODULE_IGNORE_ID_NAME = "__varname_ignore_id__"
 
@@ -135,12 +140,18 @@ def get_node_by_frame(
 def lookfor_parent_assign(
     node: ast.AST,
     direct: bool = False,
-) -> Union[ast.Assign, ast.AnnAssign]:
+    named_expr: bool = False
+) -> AssignType:
     """Look for an ast.Assign node in the parents"""
+    if named_expr:
+        types = (ast.AnnAssign, ast.Assign, ast.NamedExpr)
+    else:
+        types = (ast.AnnAssign, ast.Assign)
+
     while hasattr(node, "parent"):
         node = node.parent
 
-        if isinstance(node, (ast.AnnAssign, ast.Assign)):
+        if isinstance(node, types):
             return node
 
         if direct:


### PR DESCRIPTION
So I wanted to restrict `varname` to only return the variable name if the result of the call is assigned directly to it. Basically, `x = function()` should work, but not `x = [function()]` or `x = foo(function())`, etc. (To be more precise, I wanted `x = function(y)` to grab "x", but `x = [function(y)]` to grab "y", hence the conundrum).

I didn't see a way to do it with the current version of the package, but it seemed simple enough, so I made a modded version for my own use, then I figured I might as well make a PR if this can be useful to others. I chose to implement it by adding a `direct` argument that defaults to False.

Also, while I'm at it, I added support for the walrus operator (`a := function()`). This would technically change the current behavior on code like `a = b := function()`, so I implemented it as an option that defaults to False, but that's up to you.

I know this is unrequested and might only be relevant to my own horrendous contraptions, so no worries if you don't think these options are good or useful :)
