### PR TITLE
Add strict mode to varname

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,20 @@ Special thanks to [@HanyuuLu][2] to give up the name `varname` in pypi for this 
     func = asyncio.run(function()) # func == 'func'
     ```
 
+    Use `strict` to control whether the call should be assigned to
+    the variable directly:
+    ```python
+    def function(strict):
+        return varname(strict=strict)
+
+    func = function(True)     # OK, direct assignment, func == 'func'
+
+    func = [function(True)]   # Not a direct assignment, raises ImproperUseError
+    func = [function(False)]  # OK, func == ['func']
+
+    func = function(False), function(False)   # OK, func = ('func', 'func')
+    ```
+
 - Retrieving name of a class instance
 
     ```python
@@ -137,12 +151,6 @@ Special thanks to [@HanyuuLu][2] to give up the name `varname` in pypi for this 
     ```python
     def function():
         return varname()
-
-    func = [function()]    # func == ['func']
-
-    func = [function(), function()] # func == ['func', 'func']
-
-    func = function(), function()   # func = ('func', 'func')
 
     func = func1 = function()  # func == func1 == 'func'
     # a warning will be shown

--- a/tests/test_varname.py
+++ b/tests/test_varname.py
@@ -22,18 +22,6 @@ def test_function():
     func = function()
     assert func == 'func'
 
-    func = [function()]
-    assert func == ['func']
-
-    func = [function(), function()]
-    assert func == ['func', 'func']
-
-    func = (function(), )
-    assert func == ('func', )
-
-    func = (function(), function())
-    assert func == ('func', 'func')
-
 def test_function_with_frame_arg():
 
     def function():
@@ -132,13 +120,53 @@ def test_raise_exc():
     def get_name(raise_exc):
         return varname(raise_exc=raise_exc)
 
-    with pytest.raises(VarnameRetrievingError):
+    with pytest.raises(ImproperUseError):
         get_name(True)
 
     name = "0"
     # we can't get it in such way.
     name += str(get_name(False))
     assert name == '0None'
+
+def test_strict():
+
+    def foo(x):
+        return x
+
+    def function():
+        return varname(strict=True)
+
+    func = function()
+    assert func == 'func'
+
+    with pytest.raises(ImproperUseError):
+        func = function() + "_"
+
+    with pytest.raises(ImproperUseError):
+        func = foo(function())
+
+    with pytest.raises(ImproperUseError):
+        func = [function()]
+
+def test_not_strict():
+
+    def function():
+        return varname(strict=False)
+
+    func = function()
+    assert func == 'func'
+
+    func = [function()]
+    assert func == ['func']
+
+    func = [function(), function()]
+    assert func == ['func', 'func']
+
+    func = (function(), )
+    assert func == ('func', )
+
+    func = (function(), function())
+    assert func == ('func', 'func')
 
 def test_multiple_targets():
 
@@ -160,7 +188,7 @@ def test_unusual():
     assert xyz == 'z'
 
     x = 'a'
-    with pytest.raises(VarnameRetrievingError):
+    with pytest.raises(ImproperUseError):
         x += function()
     assert x == 'a'
 
@@ -366,7 +394,7 @@ def test_ignore_decorated():
     def foo7():
         return varname(ignore=(foo4, 100))
 
-    with pytest.raises(VarnameRetrievingError):
+    with pytest.raises(ImproperUseError):
         f6 = foo6()
 
 def test_ignore_dirname(tmp_path):

--- a/varname/helpers.py
+++ b/varname/helpers.py
@@ -14,6 +14,7 @@ def register(
     ignore: IgnoreType = None,
     multi_vars: bool = False,
     raise_exc: bool = True,
+    strict: bool = None,
 ) -> Union[Type, Callable]:
     """A decorator to register __varname__ to a class or function
 
@@ -31,6 +32,8 @@ def register(
             `VarnameRetrievingError` will be raised.
         raise_exc: Whether we should raise an exception if failed
             to retrieve the name.
+        strict: Whether to only return the variable name if the result of
+            the call is assigned to it directly.
 
     Examples:
         >>> @varname.register
@@ -58,6 +61,7 @@ def register(
                 ignore=ignore,
                 multi_vars=multi_vars,
                 raise_exc=raise_exc,
+                strict=strict,
             )
             orig_init(self, *args, **kwargs)
 
@@ -74,6 +78,7 @@ def register(
                 ignore=ignore,
                 multi_vars=multi_vars,
                 raise_exc=raise_exc,
+                strict=strict,
             )
 
             try:
@@ -90,6 +95,7 @@ def register(
         ignore=ignore,
         multi_vars=multi_vars,
         raise_exc=raise_exc,
+        strict=strict,
     )
 
 
@@ -109,6 +115,8 @@ class Wrapper:
     Args:
         value: The value to be wrapped
         raise_exc: Whether to raise exception when varname is failed to retrieve
+        strict: Whether to only return the variable name if the wrapper is
+            assigned to it directly.
 
     Attributes:
         name: The variable name to which the instance is assigned
@@ -121,9 +129,15 @@ class Wrapper:
         frame: int = 1,
         ignore: IgnoreType = None,
         raise_exc: bool = True,
+        strict: bool = None,
     ):
         # This call is ignored, since it's inside varname
-        self.name = varname(frame - 1, ignore=ignore, raise_exc=raise_exc)
+        self.name = varname(
+            frame=frame - 1,
+            ignore=ignore,
+            raise_exc=raise_exc,
+            strict=strict,
+        )
         self.value = value
 
     def __str__(self) -> str:

--- a/varname/utils.py
+++ b/varname/utils.py
@@ -132,13 +132,19 @@ def get_node_by_frame(
     return None
 
 
-def lookfor_parent_assign(node: ast.AST) -> Union[ast.Assign, ast.AnnAssign]:
+def lookfor_parent_assign(
+    node: ast.AST,
+    strict: bool = True,
+) -> Union[ast.Assign, ast.AnnAssign]:
     """Look for an ast.Assign node in the parents"""
     while hasattr(node, "parent"):
         node = node.parent
 
         if isinstance(node, (ast.AnnAssign, ast.Assign)):
             return node
+
+        if strict:
+            break
     return None
 
 


### PR DESCRIPTION
This adds a `strict` argument to `varname`, `register` and `Wrapper` that requires a direct assignment to the variable. In other words:

```python
def function(strict):
    return varname(strict=strict)

func = function(True)     # OK, direct assignment, func == 'func'

func = [function(True)]   # Not a direct assignment, raises ImproperUseError
func = [function(False)]  # OK, func == ['func']

func = function(False), function(False)   # OK, func = ('func', 'func')
```

Insofar that the plan is for `strict` to default to `True` starting in 0.8.0, when `strict` is not given and the assignment is not direct, the old behavior is preserved but displays a deprecation warning.

Supersedes #56 
