### PR TITLE
Support the walrus operator (:=)

### DIFF
--- a/tests/named_expr.py
+++ b/tests/named_expr.py
@@ -1,0 +1,8 @@
+"""Contains code that is only importable with Python >= 3.8."""
+
+from varname import varname
+
+def function():
+    return varname()
+
+a = [b := function(), c := function()]

--- a/tests/test_varname.py
+++ b/tests/test_varname.py
@@ -168,6 +168,14 @@ def test_not_strict():
     func = (function(), function())
     assert func == ('func', 'func')
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 8),
+    reason="named expressions require Python >= 3.8"
+)
+def test_named_expr():
+    from .named_expr import a
+    assert a == ["b", "c"]
+
 def test_multiple_targets():
 
     def function():

--- a/varname/core.py
+++ b/varname/core.py
@@ -134,9 +134,7 @@ def varname(
             raise ImproperUseError(msg)
         return None
 
-    if isinstance(node, ast.AnnAssign):
-        target = node.target
-    else:
+    if isinstance(node, ast.Assign):
         # Need to actually check that there's just one
         # give warnings if: a = b = func()
         if len(node.targets) > 1:
@@ -146,6 +144,8 @@ def varname(
                 MultiTargetAssignmentWarning,
             )
         target = node.targets[0]
+    else:
+        target = node.target
 
     names = node_name(target)
 

--- a/varname/utils.py
+++ b/varname/utils.py
@@ -42,6 +42,13 @@ ArgSourceType = Union[ast.AST, str]
 ArgSourceType = Union[ArgSourceType, Tuple[ArgSourceType, ...]]
 ArgSourceType = Union[ArgSourceType, Mapping[str, ArgSourceType]]
 
+if sys.version_info >= (3, 8):
+    assign_types = (ast.Assign, ast.AnnAssign, ast.NamedExpr)
+    AssignType = Union[assign_types]
+else:
+    assign_types = (ast.Assign, ast.AnnAssign)
+    AssignType = Union[assign_types]
+
 MODULE_IGNORE_ID_NAME = "__varname_ignore_id__"
 
 
@@ -132,15 +139,12 @@ def get_node_by_frame(
     return None
 
 
-def lookfor_parent_assign(
-    node: ast.AST,
-    strict: bool = True,
-) -> Union[ast.Assign, ast.AnnAssign]:
+def lookfor_parent_assign(node: ast.AST, strict: bool = True) -> AssignType:
     """Look for an ast.Assign node in the parents"""
     while hasattr(node, "parent"):
         node = node.parent
 
-        if isinstance(node, (ast.AnnAssign, ast.Assign)):
+        if isinstance(node, assign_types):
             return node
 
         if strict:


### PR DESCRIPTION
This adds support in `varname()` for the walrus operator, so that `a := function()` would return "a".

This may lead to different behavior on existing code such as `a = [b := function()]` (previously: "a", now: "b"), but this change is arguably more in line with user intent.
