### PR TITLE
0.8.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
 
     steps:
       - uses: actions/checkout@v2

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,14 @@
+## v0.8.2
+
+### Fixes
+- 🩹 Use sysconfig instead of distutils.sysconfig to avoid deprecatewarning for python 3.10+
+
+### Housekeeping
+- 👷 Add python3.10 in CI
+- 📄 Add license back
+
 ## v0.8.1
+
 - Handle inspect raises "could not get source code" when printing rich exception message
 
 ## v0.8.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "varname"
-version = "0.8.1"
+version = "0.8.2"
 description = "Dark magics about variable names in python."
 authors = [ "pwwang <pwwang@pwwang.com>",]
 license = "MIT"

--- a/varname/__init__.py
+++ b/varname/__init__.py
@@ -13,4 +13,4 @@ from .utils import (
 )
 from .core import varname, nameof, will, argname, argname2
 
-__version__ = "0.8.1"
+__version__ = "0.8.2"

--- a/varname/ignore.py
+++ b/varname/ignore.py
@@ -19,7 +19,6 @@ Any frames in `varname`, standard libraries, and frames of any expressions like
 """
 import sys
 import inspect
-from distutils import sysconfig
 import warnings
 from os import path
 from pathlib import Path
@@ -29,6 +28,14 @@ from typing import List, Union
 from types import FrameType, ModuleType, FunctionType
 
 from executing import Source
+
+try:
+    import sysconfig  # 3.10+
+except ImportError:  # pragma: no cover
+    from distutils import sysconfig
+    STANDLIB_PATH = sysconfig.get_python_lib(standard_lib=True)
+else:
+    STANDLIB_PATH = sysconfig.get_path('stdlib')
 
 from .utils import (
     IgnoreElemType,
@@ -317,9 +324,7 @@ class IgnoreList:
             ignore = [ignore]
 
         ignore_list = [
-            IgnoreStdlib(  # type: ignore
-                sysconfig.get_python_lib(standard_lib=True)
-            )
+            IgnoreStdlib(STANDLIB_PATH)  # type: ignore
         ]  # type: List[IgnoreElem]
         if ignore_varname:
             ignore_list.append(create_ignore_elem(sys.modules[__package__]))


### PR DESCRIPTION

### Fixes
- 🩹 Use sysconfig instead of distutils.sysconfig to avoid deprecatewarning for python 3.10+ (#71)

### Housekeeping
- 👷 Add python3.10 in CI
- 📄 Add license back