### PR TITLE
0.9.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install flake8
           python -m pip install mypy
+          python -m pip install typing_extensions
           python -m pip install poetry
           poetry config virtualenvs.create false
           poetry install -v

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,11 +24,11 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install flake8
-          python -m pip install mypy==0.910
           python -m pip install poetry
           poetry config virtualenvs.create false
-          poetry install -v
+          poetry install -E all -v
+          python -m pip install flake8
+          python -m pip install mypy
       - name: Run mypy check
         run: mypy -p varname
       - name: Run flake8

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,8 +25,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install flake8
-          python -m pip install mypy
-          python -m pip install typing_extensions
+          python -m pip install mypy==0.910
           python -m pip install poetry
           poetry config virtualenvs.create false
           poetry install -v

--- a/.gitignore
+++ b/.gitignore
@@ -101,7 +101,7 @@ export/
 site/
 
 # poetry
-poetry.lock
+# poetry.lock
 
 # backup files
 *.bak

--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,4 @@ docs/api/
 .history/
 
 playground/playground.nbconvert.ipynb
+test.py

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ pip install -U varname
   - A decorator to register `__varname__` to functions/classes, using `register`
   - A `debug` function to print variables with their names and values
 
-
 ## Credits
 
 Thanks goes to these awesome people/projects:
@@ -307,6 +306,16 @@ func3(x+y, y+x) # prints: ('x+y', 'y+x')
 def func4(*args, **kwargs):
     print(argname('args[1]', 'kwargs[c]'))
 func4(y, x, c=z) # prints: ('x', 'z')
+
+
+# As of 0.9.0
+# Can also fetch the source of the argument for
+# __getattr__/__getitem__/__setattr/__setitem__/__add__/__lt__, etc.
+class Foo:
+    def __setattr__(self, name, value):
+        print(argname("name", "value"))
+
+Foo().a = 1 # prints: ("'a'", '1')
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ def func4(*args, **kwargs):
 func4(y, x, c=z) # prints: ('x', 'z')
 
 
-# As of 0.9.0
+# As of 0.9.0 (see: https://pwwang.github.io/python-varname/CHANGELOG/#v090)
 # Can also fetch the source of the argument for
 # __getattr__/__getitem__/__setattr/__setitem__/__add__/__lt__, etc.
 class Foo:

--- a/README.raw.md
+++ b/README.raw.md
@@ -6,7 +6,7 @@
 
 Dark magics about variable names in python
 
-[Change Log][16] | [API][15] | [Playground][11]
+[CHANGELOG][16] | [API][15] | [Playground][11] | :fire: [StackOverflow answer][20]
 
 ## Installation
 ```shell
@@ -35,6 +35,12 @@ Thanks goes to these awesome people/projects:
 <table>
   <tr>
     <td align="center" style="min-width: 75px">
+      <a href="https://github.com/alexmojaki/executing">
+        <img src="https://ui-avatars.com/api/?color=3333ff&background=ffffff&bold=true&name=e&size=400" width="50px;" alt=""/>
+        <br /><sub><b>executing</b></sub>
+      </a>
+    </td>
+    <td align="center" style="min-width: 75px">
       <a href="https://github.com/alexmojaki">
         <img src="https://avatars0.githubusercontent.com/u/3627481?s=400&v=4" width="50px;" alt=""/>
         <br /><sub><b>@alexmojaki</b></sub>
@@ -47,9 +53,21 @@ Thanks goes to these awesome people/projects:
       </a>
     </td>
     <td align="center" style="min-width: 75px">
-      <a href="https://github.com/alexmojaki/executing">
-        <img src="https://ui-avatars.com/api/?color=3333ff&background=ffffff&bold=true&name=e&size=400" width="50px;" alt=""/>
-        <br /><sub><b>executing</b></sub>
+      <a href="https://github.com/ElCuboNegro">
+        <img src="https://avatars.githubusercontent.com/u/5524219?s=400&v=4" width="50px;" alt=""/>
+        <br /><sub><b>@ElCuboNegro</b></sub>
+      </a>
+    </td>
+    <td align="center" style="min-width: 75px">
+      <a href="https://github.com/thewchan">
+        <img src="https://avatars.githubusercontent.com/u/49702524?s=400&v=4" width="50px;" alt=""/>
+        <br /><sub><b>@thewchan</b></sub>
+      </a>
+    </td>
+    <td align="center" style="min-width: 75px">
+      <a href="https://github.com/LawsOfSympathy">
+        <img src="https://avatars.githubusercontent.com/u/96355982?s=400&v=4" width="50px;" alt=""/>
+        <br /><sub><b>@LawsOfSympathy</b></sub>
       </a>
     </td>
   </tr>
@@ -285,6 +303,15 @@ func3(x+y, y+x) # prints: {_out}
 def func4(*args, **kwargs):
     print(argname('args[1]', 'kwargs[c]'))
 func4(y, x, c=z) # prints: {_out}
+
+# As of 0.9.0
+# Can also fetch the source of the argument for
+# __getattr__/__getitem__/__setattr/__setitem__/__add__/__lt__, etc.
+class Foo:
+    def __setattr__(self, name, value):
+        print(argname("name", "value"))
+
+Foo().a = 1 # prints: {_out}
 ```
 
 ### Value wrapper
@@ -369,3 +396,4 @@ For example:
 [17]: https://img.shields.io/gitter/room/pwwang/python-varname?style=flat-square
 [18]: https://gitter.im/python-varname/community
 [19]: https://github.com/alexmojaki/executing#is-it-reliable
+[20]: https://stackoverflow.com/a/59364138/5088165

--- a/README.raw.md
+++ b/README.raw.md
@@ -304,7 +304,7 @@ def func4(*args, **kwargs):
     print(argname('args[1]', 'kwargs[c]'))
 func4(y, x, c=z) # prints: {_out}
 
-# As of 0.9.0
+# As of 0.9.0 (see: https://pwwang.github.io/python-varname/CHANGELOG/#v090)
 # Can also fetch the source of the argument for
 # __getattr__/__getitem__/__setattr/__setitem__/__add__/__lt__, etc.
 class Foo:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,44 @@
+## 0.9.0
+
+- ⬆️ Upgrade executing to 0.9
+- 🗑️ Remove deprecated `argname2`
+- ✨ Support constants for `argname` even when `vars_only=True`
+- ✨ Support `__getattr__/__setattr__` etc for `argname`
+
+    Now you can do:
+    ```python
+    from varname import argname
+
+    class Foo:
+        def __getattr__(self, name):
+            """Similar for `__getitem__`"""
+            print(argname("name"))
+
+        def __setattr__(self, name, value):
+            """Similar for `__setitem__`"""
+            print(argname("name"))
+            print(argname("value"))
+
+        def __add__(self, other):
+            """Similar for `__sub__`, `__mul__`, `__truediv__`, `__floordiv__`,
+            `__mod__`, `__pow__`, `__lshift__`, `__rshift__`, `__matmul__`,
+            `__and__`, `__xor__`, `__or__`
+            """
+            print(argname("other"))
+
+        def __eq__(self, other):
+            """Similar for `__lt__`, `__le__`, `__gt__`, `__ge__`, `__ne__`
+            """
+            print(argname("other"))
+
+    foo = Foo()
+    b = 1
+    foo.x  # prints: 'x' (note the quotes)
+    foo.x = b  # prints: 'x' and b
+    foo + b  # prints: b
+    foo == b  # prints: b
+    ```
+
 ## v0.8.3
 
 This is more of a housekeeping release:

--- a/playground/playground.ipynb
+++ b/playground/playground.ipynb
@@ -23,7 +23,7 @@
     "from contextlib import contextmanager\n",
     "\n",
     "from varname import (\n",
-    "    varname, nameof, will, argname, argname2,\n",
+    "    varname, nameof, will, argname,\n",
     "    config, \n",
     "    ImproperUseError, VarnameRetrievingError, QualnameNonUniqueError\n",
     ")\n",
@@ -369,7 +369,7 @@
      "text": [
       "ImproperUseError(Caller doesn't assign the result directly to variable(s).\n",
       "\n",
-      "  <ipython-input-9-aa71568f2d09>:11:12\n",
+      "  /tmp/ipykernel_415/1606438573.py:11:12\n",
       "    | 9   @decor\n",
       "    | 10  def func2():\n",
       "  > | 11      return func()\n",
@@ -382,7 +382,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/pwwang/github/python-varname/varname/ignore.py:171: MaybeDecoratedFunctionWarning: You asked varname to ignore function 'wrapper', which may be decorated. If it is not intended, you may need to ignore all intermediate frames with a tuple of the function and the number of its decorators.\n",
+      "/home/pwwang/github/python-varname/varname/ignore.py:175: MaybeDecoratedFunctionWarning: You asked varname to ignore function 'wrapper', which may be decorated. If it is not intended, you may need to ignore all intermediate frames with a tuple of the function and the number of its decorators.\n",
       "  warnings.warn(\n"
      ]
     }
@@ -470,12 +470,12 @@
      "output_type": "stream",
      "text": [
       "[varname] DEBUG: >>> IgnoreList initiated <<<\n",
-      "[varname] DEBUG: Ignored by IgnoreModule('varname') [In 'varname' at /home/pwwang/github/python-varname/varname/core.py:103]\n",
+      "[varname] DEBUG: Ignored by IgnoreModule('varname') [In 'varname' at /home/pwwang/github/python-varname/varname/core.py:106]\n",
       "[varname] DEBUG: Ignored by IgnoreModule('module_all_calls') [In 'func' at /home/pwwang/github/python-varname/playground/module_all_calls.py:6]\n",
       "[varname] DEBUG: Ignored by IgnoreModule('module_all_calls') [In 'func2' at /home/pwwang/github/python-varname/playground/module_all_calls.py:9]\n",
       "[varname] DEBUG: Ignored by IgnoreModule('module_all_calls') [In 'func3' at /home/pwwang/github/python-varname/playground/module_all_calls.py:12]\n",
-      "[varname] DEBUG: Skipping (0 more to skip) [In 'func' at <ipython-input-11-8d0a7ff1a188>:4]\n",
-      "[varname] DEBUG: Gotcha! [In '<module>' at <ipython-input-11-8d0a7ff1a188>:7]\n"
+      "[varname] DEBUG: Skipping (0 more to skip) [In 'func' at /tmp/ipykernel_415/3068660293.py:4]\n",
+      "[varname] DEBUG: Gotcha! [In '<cell line: 6>' at /tmp/ipykernel_415/3068660293.py:7]\n"
      ]
     },
     {
@@ -525,11 +525,11 @@
      "output_type": "stream",
      "text": [
       "[varname] DEBUG: >>> IgnoreList initiated <<<\n",
-      "[varname] DEBUG: Ignored by IgnoreModule('varname') [In 'varname' at /home/pwwang/github/python-varname/varname/core.py:103]\n",
+      "[varname] DEBUG: Ignored by IgnoreModule('varname') [In 'varname' at /home/pwwang/github/python-varname/varname/core.py:106]\n",
       "[varname] DEBUG: Ignored by IgnoreModuleQualname('module_glob_qualname', '_func*') [In '_func' at /home/pwwang/github/python-varname/playground/module_glob_qualname.py:6]\n",
       "[varname] DEBUG: Ignored by IgnoreModuleQualname('module_glob_qualname', '_func*') [In '_func2' at /home/pwwang/github/python-varname/playground/module_glob_qualname.py:9]\n",
       "[varname] DEBUG: Skipping (0 more to skip) [In 'func3' at /home/pwwang/github/python-varname/playground/module_glob_qualname.py:12]\n",
-      "[varname] DEBUG: Gotcha! [In '<module>' at <ipython-input-12-07ea87f561cc>:4]\n"
+      "[varname] DEBUG: Gotcha! [In '<cell line: 3>' at /tmp/ipykernel_415/491507787.py:4]\n"
      ]
     },
     {
@@ -610,10 +610,10 @@
      "output_type": "stream",
      "text": [
       "[varname] DEBUG: >>> IgnoreList initiated <<<\n",
-      "[varname] DEBUG: Ignored by IgnoreModule('varname') [In 'varname' at /home/pwwang/github/python-varname/varname/core.py:103]\n",
-      "[varname] DEBUG: Skipping (0 more to skip) [In 'func' at <ipython-input-14-d27bbc23b8df>:2]\n",
-      "[varname] DEBUG: Ignored by IgnoreOnlyQualname(None, '*<lambda>') [In '<lambda>' at <ipython-input-14-d27bbc23b8df>:4]\n",
-      "[varname] DEBUG: Gotcha! [In '<module>' at <ipython-input-14-d27bbc23b8df>:7]\n"
+      "[varname] DEBUG: Ignored by IgnoreModule('varname') [In 'varname' at /home/pwwang/github/python-varname/varname/core.py:106]\n",
+      "[varname] DEBUG: Skipping (0 more to skip) [In 'func' at /tmp/ipykernel_415/2761136102.py:2]\n",
+      "[varname] DEBUG: Ignored by IgnoreOnlyQualname(None, '*<lambda>') [In '<lambda>' at /tmp/ipykernel_415/2761136102.py:4]\n",
+      "[varname] DEBUG: Gotcha! [In '<cell line: 6>' at /tmp/ipykernel_415/2761136102.py:7]\n"
      ]
     },
     {
@@ -662,10 +662,10 @@
      "output_type": "stream",
      "text": [
       "[varname] DEBUG: >>> IgnoreList initiated <<<\n",
-      "[varname] DEBUG: Ignored by IgnoreModule('varname') [In 'varname' at /home/pwwang/github/python-varname/varname/core.py:103]\n",
-      "[varname] DEBUG: Skipping (0 more to skip) [In '__init__' at <ipython-input-15-32fa2de0b542>:8]\n",
+      "[varname] DEBUG: Ignored by IgnoreModule('varname') [In 'varname' at /home/pwwang/github/python-varname/varname/core.py:106]\n",
+      "[varname] DEBUG: Skipping (0 more to skip) [In '__init__' at /tmp/ipykernel_415/641638691.py:8]\n",
       "[varname] DEBUG: Ignored by IgnoreStdlib('/home/pwwang/miniconda3/lib/python3.9/') [In '__call__' at /home/pwwang/miniconda3/lib/python3.9/typing.py:670]\n",
-      "[varname] DEBUG: Gotcha! [In '<module>' at <ipython-input-15-32fa2de0b542>:11]\n"
+      "[varname] DEBUG: Gotcha! [In '<cell line: 10>' at /tmp/ipykernel_415/641638691.py:11]\n"
      ]
     },
     {
@@ -805,11 +805,11 @@
      "output_type": "stream",
      "text": [
       "[varname] DEBUG: >>> IgnoreList initiated <<<\n",
-      "[varname] DEBUG: Ignored by IgnoreModule('varname') [In 'varname' at /home/pwwang/github/python-varname/varname/core.py:103]\n",
-      "[varname] DEBUG: Ignored by IgnoreDecorated('wrapper', 2) [In 'func' at <ipython-input-18-e7a4675a5e8e>:2]\n",
-      "[varname] DEBUG: Skipping (1 more to skip) [In 'wrapper' at <ipython-input-18-e7a4675a5e8e>:9]\n",
-      "[varname] DEBUG: Skipping (0 more to skip) [In 'func3' at <ipython-input-18-e7a4675a5e8e>:18]\n",
-      "[varname] DEBUG: Gotcha! [In '<module>' at <ipython-input-18-e7a4675a5e8e>:21]\n"
+      "[varname] DEBUG: Ignored by IgnoreModule('varname') [In 'varname' at /home/pwwang/github/python-varname/varname/core.py:106]\n",
+      "[varname] DEBUG: Ignored by IgnoreDecorated('wrapper', 2) [In 'func' at /tmp/ipykernel_415/652967550.py:2]\n",
+      "[varname] DEBUG: Skipping (1 more to skip) [In 'wrapper' at /tmp/ipykernel_415/652967550.py:9]\n",
+      "[varname] DEBUG: Skipping (0 more to skip) [In 'func3' at /tmp/ipykernel_415/652967550.py:18]\n",
+      "[varname] DEBUG: Gotcha! [In '<cell line: 20>' at /tmp/ipykernel_415/652967550.py:21]\n"
      ]
     },
     {
@@ -988,7 +988,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/pwwang/github/python-varname/varname/core.py:122: MultiTargetAssignmentWarning: Multiple targets in assignment, variable name on the very right is used. \n",
+      "/home/pwwang/github/python-varname/varname/core.py:125: MultiTargetAssignmentWarning: Multiple targets in assignment, variable name on the very right is used. \n",
       "  warnings.warn(\n"
      ]
     }
@@ -1182,7 +1182,16 @@
       "x\n",
       "('y', 'x')\n",
       "('x+y', 'y+x')\n",
-      "('x', 'z')\n"
+      "('x', 'z')\n",
+      "(\"'a'\", '1')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/pwwang/github/python-varname/varname/utils.py:418: UsingExecWarning: Cannot evaluate node Attribute(value=Call(func=Name(id='Foo', ctx=Load()), args=[], keywords=[]), attr='__setattr__', ctx=Load()) using 'pure_eval'. Using 'eval' to get the function that calls 'argname'. Try calling it using a variable reference to the function, or passing the function to 'argname' explicitly.\n",
+      "  warnings.warn(\n"
      ]
     }
    ],
@@ -1211,7 +1220,15 @@
     "    # print(argname(args[1], kwargs['c']))  \n",
     "    print(argname('args[1]', 'kwargs[c]'))  \n",
     "func4(y, x, c=z)\n",
-    "\n"
+    "\n",
+    "# As of 0.9.0\n",
+    "# Can also fetch the source of the argument for\n",
+    "# __getattr__/__getitem__/__setattr/__setitem__/__add__/__lt__, etc.\n",
+    "class Foo:\n",
+    "    def __setattr__(self, name, value):\n",
+    "        print(argname(\"name\", \"value\"))\n",
+    "\n",
+    "Foo().a = 1 # prints: {_out}"
    ]
   },
   {
@@ -1235,7 +1252,7 @@
     }
    ],
    "source": [
-    "# It is easier to wrap argname2\n",
+    "# It is easier to wrap argname\n",
     "# You don't have to use the exact signature\n",
     "def argname3(*args):\n",
     "    return argname(*args, frame=2)\n",
@@ -1477,11 +1494,9 @@
   }
  ],
  "metadata": {
-  "interpreter": {
-   "hash": "c4cc73b080e063fcebb9afb794613be7caf4b26129562cba1382945a18cc49cc"
-  },
   "kernelspec": {
-   "display_name": "Python 3.9.5 64-bit ('base': conda)",
+   "display_name": "Python 3.9.5 ('base')",
+   "language": "python",
    "name": "python3"
   },
   "language_info": {
@@ -1495,6 +1510,11 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.9.5"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "9ed5c94d10bf621c6841991b7e31ffd0f3c8de8ec4167710459737a50edc58e4"
+   }
   }
  },
  "nbformat": 4,

--- a/poetry.lock
+++ b/poetry.lock
@@ -221,7 +221,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "d80b63bee9d23c8490d8accdd1327abdbca651934385fd4bac3d475c03f888d2"
+content-hash = "c0cee23f7280330270e00dd47aef14368473dc1c6d399516fa48bd4bda582873"
 
 [metadata.files]
 asttokens = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -3,7 +3,7 @@ name = "asttokens"
 version = "2.0.5"
 description = "Annotate AST trees with source code positions"
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 
 [package.dependencies]
@@ -120,7 +120,7 @@ name = "pure-eval"
 version = "0.2.2"
 description = "Safely evaluate AST nodes without side effects"
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 
 [package.extras]
@@ -187,7 +187,7 @@ name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
@@ -218,10 +218,13 @@ python-versions = ">=3.6"
 docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
+[extras]
+all = ["asttokens", "pure_eval"]
+
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "c0cee23f7280330270e00dd47aef14368473dc1c6d399516fa48bd4bda582873"
+content-hash = "f03990ad9974a874ac5538d78b9371dfdd0bb9a6c1e2bc0061db988cb240139b"
 
 [metadata.files]
 asttokens = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,0 +1,341 @@
+[[package]]
+name = "asttokens"
+version = "2.0.5"
+description = "Annotate AST trees with source code positions"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+six = "*"
+
+[package.extras]
+test = ["astroid", "pytest"]
+
+[[package]]
+name = "atomicwrites"
+version = "1.4.1"
+description = "Atomic file writes."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "attrs"
+version = "21.4.0"
+description = "Classes Without Boilerplate"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[package.extras]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
+docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "cloudpickle"]
+
+[[package]]
+name = "colorama"
+version = "0.4.5"
+description = "Cross-platform colored terminal text."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "coverage"
+version = "6.2"
+description = "Code coverage measurement for Python"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+tomli = {version = "*", optional = true, markers = "extra == \"toml\""}
+
+[package.extras]
+toml = ["tomli"]
+
+[[package]]
+name = "executing"
+version = "0.9.0"
+description = "Get the currently executing AST node of a frame, and other information"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "importlib-metadata"
+version = "4.8.3"
+description = "Read metadata from Python packages"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
+zipp = ">=0.5"
+
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
+perf = ["ipython"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
+
+[[package]]
+name = "iniconfig"
+version = "1.1.1"
+description = "iniconfig: brain-dead simple config-ini parsing"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "packaging"
+version = "21.3"
+description = "Core utilities for Python packages"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
+
+[[package]]
+name = "pluggy"
+version = "1.0.0"
+description = "plugin and hook calling mechanisms for python"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
+name = "pure-eval"
+version = "0.2.2"
+description = "Safely evaluate AST nodes without side effects"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.extras]
+tests = ["pytest"]
+
+[[package]]
+name = "py"
+version = "1.11.0"
+description = "library with cross-python path, ini-parsing, io, code, log facilities"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "pyparsing"
+version = "3.0.7"
+description = "Python parsing module"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+diagrams = ["jinja2", "railroad-diagrams"]
+
+[[package]]
+name = "pytest"
+version = "7.0.1"
+description = "pytest: simple powerful testing with Python"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
+attrs = ">=19.2.0"
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
+iniconfig = "*"
+packaging = "*"
+pluggy = ">=0.12,<2.0"
+py = ">=1.8.2"
+tomli = ">=1.0.0"
+
+[package.extras]
+testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
+
+[[package]]
+name = "pytest-cov"
+version = "3.0.0"
+description = "Pytest plugin for measuring coverage."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+coverage = {version = ">=5.2.1", extras = ["toml"]}
+pytest = ">=4.6"
+
+[package.extras]
+testing = ["fields", "hunter", "process-tests", "six", "pytest-xdist", "virtualenv"]
+
+[[package]]
+name = "six"
+version = "1.16.0"
+description = "Python 2 and 3 compatibility utilities"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
+name = "tomli"
+version = "1.2.3"
+description = "A lil' TOML parser"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "typing-extensions"
+version = "4.1.1"
+description = "Backported and Experimental Type Hints for Python 3.6+"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "zipp"
+version = "3.6.0"
+description = "Backport of pathlib-compatible object wrapper for zip files"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
+testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
+
+[metadata]
+lock-version = "1.1"
+python-versions = "^3.6"
+content-hash = "d80b63bee9d23c8490d8accdd1327abdbca651934385fd4bac3d475c03f888d2"
+
+[metadata.files]
+asttokens = [
+    {file = "asttokens-2.0.5-py2.py3-none-any.whl", hash = "sha256:0844691e88552595a6f4a4281a9f7f79b8dd45ca4ccea82e5e05b4bbdb76705c"},
+    {file = "asttokens-2.0.5.tar.gz", hash = "sha256:9a54c114f02c7a9480d56550932546a3f1fe71d8a02f1bc7ccd0ee3ee35cf4d5"},
+]
+atomicwrites = []
+attrs = [
+    {file = "attrs-21.4.0-py2.py3-none-any.whl", hash = "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4"},
+    {file = "attrs-21.4.0.tar.gz", hash = "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"},
+]
+colorama = [
+    {file = "colorama-0.4.5-py2.py3-none-any.whl", hash = "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da"},
+    {file = "colorama-0.4.5.tar.gz", hash = "sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4"},
+]
+coverage = [
+    {file = "coverage-6.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6dbc1536e105adda7a6312c778f15aaabe583b0e9a0b0a324990334fd458c94b"},
+    {file = "coverage-6.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:174cf9b4bef0db2e8244f82059a5a72bd47e1d40e71c68ab055425172b16b7d0"},
+    {file = "coverage-6.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:92b8c845527eae547a2a6617d336adc56394050c3ed8a6918683646328fbb6da"},
+    {file = "coverage-6.2-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c7912d1526299cb04c88288e148c6c87c0df600eca76efd99d84396cfe00ef1d"},
+    {file = "coverage-6.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:d5d2033d5db1d58ae2d62f095e1aefb6988af65b4b12cb8987af409587cc0739"},
+    {file = "coverage-6.2-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:3feac4084291642165c3a0d9eaebedf19ffa505016c4d3db15bfe235718d4971"},
+    {file = "coverage-6.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:276651978c94a8c5672ea60a2656e95a3cce2a3f31e9fb2d5ebd4c215d095840"},
+    {file = "coverage-6.2-cp310-cp310-win32.whl", hash = "sha256:f506af4f27def639ba45789fa6fde45f9a217da0be05f8910458e4557eed020c"},
+    {file = "coverage-6.2-cp310-cp310-win_amd64.whl", hash = "sha256:3f7c17209eef285c86f819ff04a6d4cbee9b33ef05cbcaae4c0b4e8e06b3ec8f"},
+    {file = "coverage-6.2-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:13362889b2d46e8d9f97c421539c97c963e34031ab0cb89e8ca83a10cc71ac76"},
+    {file = "coverage-6.2-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:22e60a3ca5acba37d1d4a2ee66e051f5b0e1b9ac950b5b0cf4aa5366eda41d47"},
+    {file = "coverage-6.2-cp311-cp311-win_amd64.whl", hash = "sha256:b637c57fdb8be84e91fac60d9325a66a5981f8086c954ea2772efe28425eaf64"},
+    {file = "coverage-6.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f467bbb837691ab5a8ca359199d3429a11a01e6dfb3d9dcc676dc035ca93c0a9"},
+    {file = "coverage-6.2-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2641f803ee9f95b1f387f3e8f3bf28d83d9b69a39e9911e5bfee832bea75240d"},
+    {file = "coverage-6.2-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:1219d760ccfafc03c0822ae2e06e3b1248a8e6d1a70928966bafc6838d3c9e48"},
+    {file = "coverage-6.2-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:9a2b5b52be0a8626fcbffd7e689781bf8c2ac01613e77feda93d96184949a98e"},
+    {file = "coverage-6.2-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:8e2c35a4c1f269704e90888e56f794e2d9c0262fb0c1b1c8c4ee44d9b9e77b5d"},
+    {file = "coverage-6.2-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:5d6b09c972ce9200264c35a1d53d43ca55ef61836d9ec60f0d44273a31aa9f17"},
+    {file = "coverage-6.2-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:e3db840a4dee542e37e09f30859f1612da90e1c5239a6a2498c473183a50e781"},
+    {file = "coverage-6.2-cp36-cp36m-win32.whl", hash = "sha256:4e547122ca2d244f7c090fe3f4b5a5861255ff66b7ab6d98f44a0222aaf8671a"},
+    {file = "coverage-6.2-cp36-cp36m-win_amd64.whl", hash = "sha256:01774a2c2c729619760320270e42cd9e797427ecfddd32c2a7b639cdc481f3c0"},
+    {file = "coverage-6.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:fb8b8ee99b3fffe4fd86f4c81b35a6bf7e4462cba019997af2fe679365db0c49"},
+    {file = "coverage-6.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:619346d57c7126ae49ac95b11b0dc8e36c1dd49d148477461bb66c8cf13bb521"},
+    {file = "coverage-6.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:0a7726f74ff63f41e95ed3a89fef002916c828bb5fcae83b505b49d81a066884"},
+    {file = "coverage-6.2-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:cfd9386c1d6f13b37e05a91a8583e802f8059bebfccde61a418c5808dea6bbfa"},
+    {file = "coverage-6.2-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:17e6c11038d4ed6e8af1407d9e89a2904d573be29d51515f14262d7f10ef0a64"},
+    {file = "coverage-6.2-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:c254b03032d5a06de049ce8bca8338a5185f07fb76600afff3c161e053d88617"},
+    {file = "coverage-6.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:dca38a21e4423f3edb821292e97cec7ad38086f84313462098568baedf4331f8"},
+    {file = "coverage-6.2-cp37-cp37m-win32.whl", hash = "sha256:600617008aa82032ddeace2535626d1bc212dfff32b43989539deda63b3f36e4"},
+    {file = "coverage-6.2-cp37-cp37m-win_amd64.whl", hash = "sha256:bf154ba7ee2fd613eb541c2bc03d3d9ac667080a737449d1a3fb342740eb1a74"},
+    {file = "coverage-6.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:f9afb5b746781fc2abce26193d1c817b7eb0e11459510fba65d2bd77fe161d9e"},
+    {file = "coverage-6.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:edcada2e24ed68f019175c2b2af2a8b481d3d084798b8c20d15d34f5c733fa58"},
+    {file = "coverage-6.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:a9c8c4283e17690ff1a7427123ffb428ad6a52ed720d550e299e8291e33184dc"},
+    {file = "coverage-6.2-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f614fc9956d76d8a88a88bb41ddc12709caa755666f580af3a688899721efecd"},
+    {file = "coverage-6.2-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:9365ed5cce5d0cf2c10afc6add145c5037d3148585b8ae0e77cc1efdd6aa2953"},
+    {file = "coverage-6.2-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:8bdfe9ff3a4ea37d17f172ac0dff1e1c383aec17a636b9b35906babc9f0f5475"},
+    {file = "coverage-6.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:63c424e6f5b4ab1cf1e23a43b12f542b0ec2e54f99ec9f11b75382152981df57"},
+    {file = "coverage-6.2-cp38-cp38-win32.whl", hash = "sha256:49dbff64961bc9bdd2289a2bda6a3a5a331964ba5497f694e2cbd540d656dc1c"},
+    {file = "coverage-6.2-cp38-cp38-win_amd64.whl", hash = "sha256:9a29311bd6429be317c1f3fe4bc06c4c5ee45e2fa61b2a19d4d1d6111cb94af2"},
+    {file = "coverage-6.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:03b20e52b7d31be571c9c06b74746746d4eb82fc260e594dc662ed48145e9efd"},
+    {file = "coverage-6.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:215f8afcc02a24c2d9a10d3790b21054b58d71f4b3c6f055d4bb1b15cecce685"},
+    {file = "coverage-6.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:a4bdeb0a52d1d04123b41d90a4390b096f3ef38eee35e11f0b22c2d031222c6c"},
+    {file = "coverage-6.2-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c332d8f8d448ded473b97fefe4a0983265af21917d8b0cdcb8bb06b2afe632c3"},
+    {file = "coverage-6.2-cp39-cp39-win32.whl", hash = "sha256:6e1394d24d5938e561fbeaa0cd3d356207579c28bd1792f25a068743f2d5b282"},
+    {file = "coverage-6.2-cp39-cp39-win_amd64.whl", hash = "sha256:86f2e78b1eff847609b1ca8050c9e1fa3bd44ce755b2ec30e70f2d3ba3844644"},
+    {file = "coverage-6.2-pp36.pp37.pp38-none-any.whl", hash = "sha256:5829192582c0ec8ca4a2532407bc14c2f338d9878a10442f5d03804a95fac9de"},
+    {file = "coverage-6.2.tar.gz", hash = "sha256:e2cad8093172b7d1595b4ad66f24270808658e11acf43a8f95b41276162eb5b8"},
+]
+executing = []
+importlib-metadata = [
+    {file = "importlib_metadata-4.8.3-py3-none-any.whl", hash = "sha256:65a9576a5b2d58ca44d133c42a241905cc45e34d2c06fd5ba2bafa221e5d7b5e"},
+    {file = "importlib_metadata-4.8.3.tar.gz", hash = "sha256:766abffff765960fcc18003801f7044eb6755ffae4521c8e8ce8e83b9c9b0668"},
+]
+iniconfig = [
+    {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
+    {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
+]
+packaging = [
+    {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
+    {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
+]
+pluggy = [
+    {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
+    {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
+]
+pure-eval = [
+    {file = "pure_eval-0.2.2-py3-none-any.whl", hash = "sha256:01eaab343580944bc56080ebe0a674b39ec44a945e6d09ba7db3cb8cec289350"},
+    {file = "pure_eval-0.2.2.tar.gz", hash = "sha256:2b45320af6dfaa1750f543d714b6d1c520a1688dec6fd24d339063ce0aaa9ac3"},
+]
+py = [
+    {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
+    {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
+]
+pyparsing = [
+    {file = "pyparsing-3.0.7-py3-none-any.whl", hash = "sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484"},
+    {file = "pyparsing-3.0.7.tar.gz", hash = "sha256:18ee9022775d270c55187733956460083db60b37d0d0fb357445f3094eed3eea"},
+]
+pytest = [
+    {file = "pytest-7.0.1-py3-none-any.whl", hash = "sha256:9ce3ff477af913ecf6321fe337b93a2c0dcf2a0a1439c43f5452112c1e4280db"},
+    {file = "pytest-7.0.1.tar.gz", hash = "sha256:e30905a0c131d3d94b89624a1cc5afec3e0ba2fbdb151867d8e0ebd49850f171"},
+]
+pytest-cov = [
+    {file = "pytest-cov-3.0.0.tar.gz", hash = "sha256:e7f0f5b1617d2210a2cabc266dfe2f4c75a8d32fb89eafb7ad9d06f6d076d470"},
+    {file = "pytest_cov-3.0.0-py3-none-any.whl", hash = "sha256:578d5d15ac4a25e5f961c938b85a05b09fdaae9deef3bb6de9a6e766622ca7a6"},
+]
+six = [
+    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
+    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]
+tomli = [
+    {file = "tomli-1.2.3-py3-none-any.whl", hash = "sha256:e3069e4be3ead9668e21cb9b074cd948f7b3113fd9c8bba083f48247aab8b11c"},
+    {file = "tomli-1.2.3.tar.gz", hash = "sha256:05b6166bff487dc068d322585c7ea4ef78deed501cc124060e0f238e89a9231f"},
+]
+typing-extensions = [
+    {file = "typing_extensions-4.1.1-py3-none-any.whl", hash = "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2"},
+    {file = "typing_extensions-4.1.1.tar.gz", hash = "sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42"},
+]
+zipp = [
+    {file = "zipp-3.6.0-py3-none-any.whl", hash = "sha256:9fe5ea21568a0a70e50f273397638d39b03353731e6cbbb3fd8502a33fec40bc"},
+    {file = "zipp-3.6.0.tar.gz", hash = "sha256:71c644c5369f4a6e07636f0aa966270449561fcea2e3d6747b8d23efaa9d7832"},
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,9 @@ pure_eval = { version = "0.*", optional = true }
 [tool.poetry.dev-dependencies]
 pytest = "^7"
 pytest-cov = "^3"
-asttokens = "2.*"
-pure_eval = "0.*"
+
+[tool.poetry.extras]
+all = ["asttokens", "pure_eval"]
 
 [tool.pytest.ini_options]
 addopts = "-vv -p no:asyncio -W error::UserWarning --cov-config=.coveragerc --cov=varname --cov-report xml:.coverage.xml --cov-report term-missing"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "varname"
-version = "0.8.3"
+version = "0.9.0"
 description = "Dark magics about variable names in python."
 authors = [ "pwwang <pwwang@pwwang.com>",]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,8 @@ asttokens = { version = "2.*", optional = true }
 pure_eval = { version = "0.*", optional = true }
 
 [tool.poetry.dev-dependencies]
-pytest = "*"
-pytest-cov = "*"
+pytest = "^7"
+pytest-cov = "^3"
 asttokens = "2.*"
 pure_eval = "0.*"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/pwwang/python-varname"
 
 [tool.poetry.dependencies]
 python = "^3.6"
-executing = "^0.8.3"
+executing = "^0.9"
 asttokens = { version = "2.*", optional = true }
 pure_eval = { version = "0.*", optional = true }
 
@@ -25,7 +25,7 @@ asttokens = "2.*"
 pure_eval = "0.*"
 
 [tool.pytest.ini_options]
-addopts = "-vv -W error::UserWarning --cov-config=.coveragerc --cov=varname --cov-report xml:.coverage.xml --cov-report term-missing"
+addopts = "-vv -p no:asyncio -W error::UserWarning --cov-config=.coveragerc --cov=varname --cov-report xml:.coverage.xml --cov-report term-missing"
 console_output_style = "progress"
 junit_family = "xunit1"
 

--- a/tests/test_argname.py
+++ b/tests/test_argname.py
@@ -34,36 +34,6 @@ def test_argname():
     names4 = func4(y, b=x)
     assert names4 == ("y", "x")
 
-def test_argname2():
-    def func(a, b, c, d=4):
-        return argname2("c", "b")
-
-    x = y = z = 1
-    with pytest.warns(DeprecationWarning):
-        names = func(x, y, z)
-    assert names == ("z", "y")
-
-    def func2(a, b, c, d=4):
-        return argname2("b")
-
-    with pytest.warns(DeprecationWarning):
-        names2 = func2(x, y, z)
-    assert names2 == "y"
-
-    def func3(e=1):
-        return argname2("e")
-
-    with pytest.warns(DeprecationWarning):
-        names3 = func3(z)
-    assert names3 == "z"
-
-    def func4(a, b=1):
-        return argname2("a", "b")
-
-    with pytest.warns(DeprecationWarning):
-        names4 = func4(y, b=x)
-    assert names4 == ("y", "x")
-
 
 def test_argname_lambda():
     func = lambda a, b, c, d=4: argname("b")

--- a/tests/test_argname.py
+++ b/tests/test_argname.py
@@ -13,6 +13,9 @@ def test_argname():
     names = func(x, y, z)
     assert names == ("z", "y")
 
+    names = func(x, "a", 1)
+    assert names == ('1', "'a'")
+
     def func2(a, b, c, d=4):
         return argname("b")
 
@@ -110,7 +113,7 @@ def test_argname_non_variable():
         return argname("b")
 
     with pytest.raises(ImproperUseError, match=r"is not a variable"):
-        func(1, 1, 1)
+        func(1, {1}, 1)
 
 
 def test_argname_argname_argument_non_variable():
@@ -126,16 +129,16 @@ def test_argname_funcnode_not_call():
     x = 1
 
     class Foo:
-        @property
-        def prop(self):
-            y = argname("x")
+
+        def __neg__(self):
+            return argname("self")
 
     foo = Foo()
     with pytest.raises(
         VarnameRetrievingError,
-        match="Are you using 'argname' inside a function",
+        match="Cannot reconstruct ast.Call node from UnaryOp",
     ):
-        foo.prop
+        -foo
 
 
 def test_argname_get_source():
@@ -410,7 +413,7 @@ def test_argname_nonvar():
         return argname("x")
 
     with pytest.raises(ImproperUseError):
-        func(1)
+        func({1})
 
 
 def test_argname_frame_error():
@@ -431,3 +434,108 @@ def test_argname_ignore():
     x = y = 1
     out = wrapper(x, y)
     assert out == ("x", "y")
+
+
+def test_argname_attribute_item():
+    class A:
+        def __init__(self):
+            self.__dict__["meta"] = {}
+
+        def __getattr__(self, name):
+            return argname("name")
+
+        def __setattr__(self, name, value) -> None:
+            self.__dict__["meta"]["name"] = argname("name")
+            self.__dict__["meta"]["name2"] = argname("name", vars_only=False)
+            self.__dict__["meta"]["value"] = argname("value")
+
+        def __getitem__(self, name):
+            return argname("name")
+
+        def __setitem__(self, name, value) -> None:
+            self.__dict__["meta"]["name"] = argname("name")
+            self.__dict__["meta"]["name2"] = argname("name", vars_only=False)
+            self.__dict__["meta"]["value"] = argname("value")
+
+
+    a = A()
+    out = a.x
+    assert out == "'x'"
+
+    a.__getattr__("x")
+    assert out == "'x'"
+
+    a.y = 1
+    assert a.meta["name"] == "'y'"
+    assert a.meta["name2"] == "'y'"
+    assert a.meta["value"] == "1"
+
+    a.__setattr__("y", 1)
+    assert a.meta["name"] == "'y'"
+    assert a.meta["name2"] == "'y'"
+    assert a.meta["value"] == "1"
+
+    out = a[1]
+    assert out == "1"
+
+    a[1] = 2
+    assert a.meta["name"] == "1"
+    assert a.meta["name2"] == "1"
+    assert a.meta["value"] == "2"
+
+    with pytest.raises(ImproperUseError):
+        a.x = a.y = 1
+
+
+def test_argname_compare():
+    class A:
+        def __init__(self):
+            self.meta = None
+
+        def __eq__(self, other):
+            self.meta = argname("other")
+            return True
+
+        def __lt__(self, other):
+            self.meta = argname("other")
+            return True
+
+        def __gt__(self, other):
+            self.meta = argname("other")
+            return True
+
+    a = A()
+    a == 1
+    assert a.meta == '1'
+
+    a < 2
+    assert a.meta == '2'
+
+    a > 3
+    assert a.meta == '3'
+
+
+def test_argname_binop():
+    class A:
+        def __init__(self):
+            self.meta = None
+
+        def __add__(self, other):
+            self.meta = argname("other")
+            return 1
+
+    a = A()
+    out = a + 1
+    assert out == 1
+    assert a.meta == '1'
+
+
+def test_argname_wrong_frame():
+    def func(x):
+        return argname("x", func=property.getter)
+
+    with pytest.raises(
+        ImproperUseError,
+        match="Have you specified the right `frame` or `func`",
+    ):
+        func(1)

--- a/varname/__init__.py
+++ b/varname/__init__.py
@@ -11,6 +11,6 @@ from .utils import (
     MaybeDecoratedFunctionWarning,
     UsingExecWarning,
 )
-from .core import varname, nameof, will, argname, argname2
+from .core import varname, nameof, will, argname
 
 __version__ = "0.8.3"

--- a/varname/__init__.py
+++ b/varname/__init__.py
@@ -13,4 +13,4 @@ from .utils import (
 )
 from .core import varname, nameof, will, argname
 
-__version__ = "0.8.3"
+__version__ = "0.9.0"

--- a/varname/core.py
+++ b/varname/core.py
@@ -339,17 +339,17 @@ def argname(
             names/sources of.
             You can also use subscripts to get parts of the results.
             >>> def func(*args, **kwargs):
-            >>>     return argname2('args[0]', 'kwargs[x]') # no quote needed
+            >>>     return argname('args[0]', 'kwargs[x]') # no quote needed
 
             Star argument is also allowed:
             >>> def func(*args, x = 1):
-            >>>     return argname2('*args', 'x')
+            >>>     return argname('*args', 'x')
             >>> a = b = c = 1
             >>> func(a, b, x=c) # ('a', 'b', 'c')
 
             Note the difference:
             >>> def func(*args, x = 1):
-            >>>     return argname2('args', 'x')
+            >>>     return argname('args', 'x')
             >>> a = b = c = 1
             >>> func(a, b, x=c) # (('a', 'b'), 'c')
 
@@ -390,7 +390,7 @@ def argname(
         ignore_lambda=False,
         ignore_varname=False,
     )
-    # where func(...) is called, skip the argname2() call
+    # where func(...) is called, skip the argname() call
     func_frame = ignore_list.get_frame(frame + 1)
     func_node = get_node_by_frame(func_frame)
     # Only do it when func_node are available
@@ -480,30 +480,4 @@ def argname(
         out[0]
         if not more_args and not farg_star
         else tuple(out)  # type: ignore
-    )
-
-
-def argname2(
-    arg: str,
-    *more_args: str,
-    func: Callable = None,
-    dispatch: Type = None,
-    frame: int = 1,
-    ignore: IgnoreType = None,
-    vars_only: bool = True,
-) -> ArgSourceType:
-    """Alias of argname, will be removed in v0.9.0"""
-    warnings.warn(
-        "`argname2()` is deprecated and will be removed in v0.9.0. "
-        "Use `argname()` instead.",
-        DeprecationWarning
-    )
-    return argname(
-        arg,
-        *more_args,
-        func=func,
-        dispatch=dispatch,
-        frame=frame + 1,
-        ignore=ignore,
-        vars_only=vars_only,
     )

--- a/varname/core.py
+++ b/varname/core.py
@@ -1,10 +1,8 @@
 """Provide core features for varname"""
-from __future__ import annotations
-
 import ast
 import re
 import warnings
-from typing import List, Tuple, Type, Callable
+from typing import List, Tuple, Type, Union, Callable
 
 from executing import Source
 
@@ -32,7 +30,7 @@ def varname(
     multi_vars: bool = False,
     raise_exc: bool = True,
     strict: bool = True,
-) -> str | Tuple[str | Tuple, ...]:
+) -> Union[str, Tuple[Union[str, Tuple], ...]]:
     """Get the name of the variable(s) that assigned by function call or
     class instantiation.
 
@@ -223,7 +221,7 @@ def nameof(
     *more_vars,
     frame: int = 1,
     vars_only: bool = True,
-) -> str | Tuple[str, ...]:
+) -> Union[str, Tuple[str, ...]]:
     """Get the names of the variables passed in
 
     Examples:

--- a/varname/helpers.py
+++ b/varname/helpers.py
@@ -9,7 +9,6 @@ from .core import argname, varname
 
 def register(
     cls_or_func: type = None,
-    # *, keyword-only argument, only available with python3.8+
     frame: int = 1,
     ignore: IgnoreType = None,
     multi_vars: bool = False,

--- a/varname/utils.py
+++ b/varname/utils.py
@@ -489,8 +489,8 @@ def _(node: ast.Attribute | ast.Subscript) -> ast.Call:
     # x[a] = b, x.a = b
     if (
         not hasattr(node, "parent")
-        or not isinstance(node.parent, ast.Assign)
-        or len(node.parent.targets) != 1
+        or not isinstance(node.parent, ast.Assign)  # type: ignore
+        or len(node.parent.targets) != 1  # type: ignore
     ):
         raise ImproperUseError(
             rich_exc_message(
@@ -511,7 +511,7 @@ def _(node: ast.Attribute | ast.Subscript) -> ast.Call:
             ctx=ast.Load(),
             **nodemeta,
         ),
-        args=[keynode, node.parent.value],
+        args=[keynode, node.parent.value],  # type: ignore
         keywords=[],
         starargs=None,
         kwargs=None,

--- a/varname/utils.py
+++ b/varname/utils.py
@@ -457,8 +457,6 @@ def _(node: ast.Attribute | ast.Subscript) -> ast.Call:
     nodemeta = {
         "lineno": node.lineno,
         "col_offset": node.col_offset,
-        "end_lineno": node.end_lineno,
-        "end_col_offset": node.end_col_offset,
     }
 
     keynode = (

--- a/varname/utils.py
+++ b/varname/utils.py
@@ -458,7 +458,6 @@ def _(node: ast.Attribute | ast.Subscript) -> ast.Call:
         "lineno": node.lineno,
         "col_offset": node.col_offset,
     }
-
     keynode = (
         node.slice
         if isinstance(node, ast.Subscript)
@@ -526,8 +525,6 @@ def _(node: ast.Compare) -> ast.Call:
     nodemeta = {
         "lineno": node.lineno,
         "col_offset": node.col_offset,
-        "end_lineno": node.end_lineno,
-        "end_col_offset": node.end_col_offset,
     }
     return ast.Call(
         func=ast.Attribute(
@@ -549,8 +546,6 @@ def _(node: ast.BinOp) -> ast.Call:
     nodemeta = {
         "lineno": node.lineno,
         "col_offset": node.col_offset,
-        "end_lineno": node.end_lineno,
-        "end_col_offset": node.end_col_offset,
     }
     return ast.Call(
         func=ast.Attribute(

--- a/varname/utils.py
+++ b/varname/utils.py
@@ -45,7 +45,6 @@ CMP2MAGIC = {
     ast.LtE: "__le__",
     ast.Gt: "__gt__",
     ast.GtE: "__ge__",
-    ast.In: "__contains__",
 }
 
 IgnoreElemType = Union[

--- a/varname/utils.py
+++ b/varname/utils.py
@@ -9,6 +9,8 @@ Attributes:
         Espectially for modules that can't be retrieved by
         `inspect.getmodule(frame)`
 """
+from __future__ import annotations
+
 import sys
 import dis
 import ast
@@ -16,11 +18,37 @@ import warnings
 import inspect
 from os import path
 from pathlib import Path
-from functools import lru_cache
+from functools import lru_cache, singledispatch
 from types import ModuleType, FunctionType, CodeType, FrameType
 from typing import Tuple, Union, List, Mapping, Callable
 
 from executing import Source
+
+OP2MAGIC = {
+    ast.Add: "__add__",
+    ast.Sub: "__sub__",
+    ast.Mult: "__mul__",
+    ast.Div: "__truediv__",
+    ast.FloorDiv: "__floordiv__",
+    ast.Mod: "__mod__",
+    ast.Pow: "__pow__",
+    ast.LShift: "__lshift__",
+    ast.RShift: "__rshift__",
+    ast.BitOr: "__or__",
+    ast.BitXor: "__xor__",
+    ast.BitAnd: "__and__",
+    ast.MatMult: "__matmul__",
+}
+
+CMP2MAGIC = {
+    ast.Eq: "__eq__",
+    ast.NotEq: "__ne__",
+    ast.Lt: "__lt__",
+    ast.LtE: "__le__",
+    ast.Gt: "__gt__",
+    ast.GtE: "__ge__",
+    ast.In: "__contains__",
+}
 
 IgnoreElemType = Union[
     # module
@@ -160,7 +188,7 @@ def lookfor_parent_assign(node: ast.AST, strict: bool = True) -> AssignType:
     return None
 
 
-def node_name(node: ast.AST) -> Union[str, Tuple[Union[str, Tuple], ...]]:
+def node_name(node: ast.AST) -> str | Tuple[str | Tuple, ...]:
     """Get the node node name.
 
     Raises ImproperUseError when failed
@@ -206,7 +234,9 @@ def bytecode_nameof(code: CodeType, offset: int) -> str:
     name_instruction = instructions[current_instruction_index - 1]
 
     if not name_instruction.opname.startswith("LOAD_"):
-        raise VarnameRetrievingError("Argument must be a variable or attribute")
+        raise VarnameRetrievingError(
+            "Argument must be a variable or attribute"
+        )
 
     name = name_instruction.argrepr
     if not name.isidentifier():
@@ -284,7 +314,7 @@ def debug_ignore_frame(msg: str, frameinfo: inspect.FrameInfo = None) -> None:
 
 def argnode_source(
     source: Source, node: ast.AST, vars_only: bool
-) -> Union[str, ast.AST]:
+) -> str | ast.AST:
     """Get the source of an argument node
 
     Args:
@@ -297,6 +327,9 @@ def argnode_source(
             node.attr for ast.Attribute). Or the node itself if the source
             cannot be fetched.
     """
+    if isinstance(node, ast.Constant):
+        return repr(node.value)
+
     if vars_only:
         return (
             node.id
@@ -332,8 +365,7 @@ def get_argument_sources(
     # func(y, x, c=z)
     # ['y', 'x'], {'c': 'z'}
     arg_sources = [
-        argnode_source(source, argnode, vars_only)
-        for argnode in node.args
+        argnode_source(source, argnode, vars_only) for argnode in node.args
     ]
     kwarg_sources = {
         argnode.arg: argnode_source(source, argnode.value, vars_only)
@@ -352,15 +384,8 @@ def get_argument_sources(
     return argument_sources
 
 
-def get_function_called_argname(frame: FrameType, node: ast.AST) -> Callable:
+def get_function_called_argname(frame: FrameType, node: ast.Call) -> Callable:
     """Get the function who called argname"""
-    # We need node to be ast.Call
-    if not isinstance(node, ast.Call):
-        raise VarnameRetrievingError(
-            f"Expect an 'ast.Call' node, but got {type(node)!r}. "
-            "Are you using 'argname' inside a function?"
-        )
-
     # variable
     if isinstance(node.func, ast.Name):
         func = frame.f_locals.get(
@@ -395,11 +420,152 @@ def get_function_called_argname(frame: FrameType, node: ast.AST) -> Callable:
         "Using 'eval' to get the function that calls 'argname'. "
         "Try calling it using a variable reference to the function, or "
         "passing the function to 'argname' explicitly.",
-        UsingExecWarning
+        UsingExecWarning,
     )
     expr = ast.Expression(node.func)
     code = compile(expr, "<ast-call>", "eval")
     return eval(code, frame.f_globals, frame.f_locals)
+
+
+@singledispatch
+def reconstruct_func_node(node: ast.AST) -> ast.Call:
+    """Reconstruct the ast.Call node from
+
+    `x.a` to `x.__getattr__('a')`
+    `x.a = b` to `x.__setattr__('a', b)`
+    `x[a]` to `x.__getitem__(a)`
+    `x[a] = b` to `x.__setitem__(a, 1)`
+    `x + a` to `x.__add__(a)`
+    `x < a` to `x.__lt__(a)`
+    """
+    raise VarnameRetrievingError(
+        f"Cannot reconstruct ast.Call node from {type(node).__name__}, "
+        "expecting Call, Attribute, Subscript, BinOp, Compare."
+    )
+
+
+@reconstruct_func_node.register(ast.Call)
+def _(node: ast.Call) -> ast.Call:
+    return node
+
+
+@reconstruct_func_node.register(ast.Attribute)
+@reconstruct_func_node.register(ast.Subscript)
+def _(node: ast.Attribute | ast.Subscript) -> ast.Call:
+    """Reconstruct the function node for
+    `x.__getitem__/__setitem__/__getattr__/__setattr__`"""
+    nodemeta = {
+        "lineno": node.lineno,
+        "col_offset": node.col_offset,
+        "end_lineno": node.end_lineno,
+        "end_col_offset": node.end_col_offset,
+    }
+
+    keynode = (
+        node.slice
+        if isinstance(node, ast.Subscript)
+        else ast.Constant(value=node.attr)
+    )
+
+    # x[1], x.a
+    if isinstance(node.ctx, ast.Load):
+        return ast.Call(
+            func=ast.Attribute(
+                value=node.value,
+                attr=(
+                    "__getitem__"
+                    if isinstance(node, ast.Subscript)
+                    else "__getattr__"
+                ),
+                ctx=ast.Load(),
+                **nodemeta,
+            ),
+            args=[keynode],
+            keywords=[],
+            starargs=None,
+            kwargs=None,
+        )
+
+    # x[a] = b, x.a = b
+    if (
+        not hasattr(node, "parent")
+        or not isinstance(node.parent, ast.Assign)
+        or len(node.parent.targets) != 1
+    ):
+        raise ImproperUseError(
+            rich_exc_message(
+                "Expect `x[a] = b` or `x.a = b` directly, got "
+                f"{ast.dump(node)}.",
+                node,
+            )
+        )
+
+    return ast.Call(
+        func=ast.Attribute(
+            value=node.value,
+            attr=(
+                "__setitem__"
+                if isinstance(node, ast.Subscript)
+                else "__setattr__"
+            ),
+            ctx=ast.Load(),
+            **nodemeta,
+        ),
+        args=[keynode, node.parent.value],
+        keywords=[],
+        starargs=None,
+        kwargs=None,
+    )
+
+
+@reconstruct_func_node.register(ast.Compare)
+def _(node: ast.Compare) -> ast.Call:
+    """Reconstruct the function node for `x < a`"""
+    # When the node is identified by executing, len(ops) is always 1.
+    # Otherwise, the node cannot be identified.
+    assert len(node.ops) == 1
+
+    nodemeta = {
+        "lineno": node.lineno,
+        "col_offset": node.col_offset,
+        "end_lineno": node.end_lineno,
+        "end_col_offset": node.end_col_offset,
+    }
+    return ast.Call(
+        func=ast.Attribute(
+            value=node.left,
+            attr=CMP2MAGIC[type(node.ops[0])],
+            ctx=ast.Load(),
+            **nodemeta,
+        ),
+        args=[node.comparators[0]],
+        keywords=[],
+        starargs=None,
+        kwargs=None,
+    )
+
+
+@reconstruct_func_node.register(ast.BinOp)
+def _(node: ast.BinOp) -> ast.Call:
+    """Reconstruct the function node for `x + a`"""
+    nodemeta = {
+        "lineno": node.lineno,
+        "col_offset": node.col_offset,
+        "end_lineno": node.end_lineno,
+        "end_col_offset": node.end_col_offset,
+    }
+    return ast.Call(
+        func=ast.Attribute(
+            value=node.left,
+            attr=OP2MAGIC[type(node.op)],
+            ctx=ast.Load(),
+            **nodemeta,
+        ),
+        args=[node.right],
+        keywords=[],
+        starargs=None,
+        kwargs=None,
+    )
 
 
 def rich_exc_message(msg: str, node: ast.AST, context_lines: int = 4) -> str:


### PR DESCRIPTION
- ⬆️ Upgrade executing to 0.9
- 🗑️ Remove deprecated `argname2`
- ✨ Support constants for `argname` even when `vars_only=True`
- ✨ Support `__getattr__/__setattr__` etc for `argname`

    Now you can do:
    ```python
    from varname import argname

    class Foo:
        def __getattr__(self, name):
            """Similar for `__getitem__`"""
            print(argname("name"))

        def __setattr__(self, name, value):
            """Similar for `__setitem__`"""
            print(argname("name"))
            print(argname("value"))

        def __add__(self, other):
            """Similar for `__sub__`, `__mul__`, `__truediv__`, `__floordiv__`,
            `__mod__`, `__pow__`, `__lshift__`, `__rshift__`, `__matmul__`,
            `__and__`, `__xor__`, `__or__`
            """
            print(argname("other"))

        def __eq__(self, other):
            """Similar for `__lt__`, `__le__`, `__gt__`, `__ge__`, `__ne__`
            """
            print(argname("other"))

    foo = Foo()
    b = 1
    foo.x  # prints: 'x' (note the quotes)
    foo.x = b  # prints: 'x' and b
    foo + b  # prints: b
    foo == b  # prints: b
    ```