### PR TITLE
Python 3.11 support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,6 +6,6 @@ root = true
 end_of_line = lf
 insert_final_newline = true
 charset = utf-8
-indent_style = tab
+indent_style = space
 indent_size = 4
 trim_trailing_whitespace = true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", 3.11-dev]
 
     steps:
       - uses: actions/checkout@v2

--- a/varname/utils.py
+++ b/varname/utils.py
@@ -236,7 +236,7 @@ def bytecode_nameof(code: CodeType, offset: int) -> str:
         raise pos_only_error
 
     if current_instruction.opname not in ("CALL_FUNCTION", "CALL_METHOD", "CALL"):
-        raise VarnameRetrievingError("Did you call 'nameof' in a weird way? " + str(current_instruction))
+        raise VarnameRetrievingError("Did you call 'nameof' in a weird way?")
 
     current_instruction_index -= 1
     name_instruction = instructions[current_instruction_index]


### PR DESCRIPTION
The latest version of `executing` now supports Python 3.11. While testing it here, I noticed that bytecode_nameof had become broken in 3.11.