### PR TITLE
switch to poetry-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = [ "poetry>=0.12",]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "varname"


### PR DESCRIPTION
based on
https://gitlab.com/sublime-music/sublime-music/-/merge_requests/60
https://github.com/NixOS/nixpkgs/pull/119204

fix

```
ModuleNotFoundError: No module named 'poetry.masonry'
ERROR Backend 'poetry.masonry.api' is not available.
```
