### PR TITLE
fix: support ast.Index, ast.ExtSlice in py3.8 when use subscript

### DIFF
--- a/varname/utils.py
+++ b/varname/utils.py
@@ -284,10 +284,15 @@ def node_name(
 
     name = type(node).__name__
     if isinstance(node, ast.Subscript):
+        node_slice = node.slice
+        if isinstance(node_slice, ast.Index):
+            node_slice = node.slice.value
+        elif isinstance(node_slice, ast.ExtSlice):
+            node_slice = ast.Tuple(node_slice.dims)
         try:
-            return f"{node_name(node.value)}[{node_name(node.slice, True)}]"
+            return f"{node_name(node.value)}[{node_name(node_slice, True)}]"
         except ImproperUseError:
-            name = f"{node_name(node.value)}[{type(node.slice).__name__}]"
+            name = f"{node_name(node.value)}[{type(node_slice).__name__}]"
 
     raise ImproperUseError(
         f"Node {name!r} detected, but only following nodes are supported: \n"


### PR DESCRIPTION
in python3.8, like a[0], a[1:4:2, 1:4:2], is ast.Name + ast.Index / ast.ExtSlice.

case in tests/test_varname.py occurre error in py3.8.

```
E       varname.utils.ImproperUseError: Node 'x[Index]' detected, but only following nodes are supported: 
varname/utils.py:292: ImproperUseError
======================================================================================================= short test summary info =======================================================================================================
FAILED tests/test_varname.py::test_multi_vars_lhs - AssertionError: Regex pattern did not match.
FAILED tests/test_varname.py::test_subscript - varname.utils.ImproperUseError: Node 'x[Index]' detected, but only following nodes are supported: 
```